### PR TITLE
Vector4とColorクラスの統合と新機能の追加

### DIFF
--- a/Math/Color.h
+++ b/Math/Color.h
@@ -1,0 +1,30 @@
+#pragma once
+
+class Vector4;
+
+/// <summary>
+/// Color class
+/// </summary>
+class Color final
+{
+public:
+    struct RGBA
+    {
+        unsigned int r : 8;
+        unsigned int g : 8;
+        unsigned int b : 8;
+        unsigned int a : 8;
+    };
+
+    RGBA rgba;
+
+    inline Color() : rgba() {};
+    Color(const Vector4& _vec4);
+    Color(unsigned int _color);
+
+
+    Vector4         Vec4()      const;
+    unsigned int    UInt32()    const;
+
+
+};

--- a/Math/Vector4.h
+++ b/Math/Vector4.h
@@ -5,6 +5,7 @@
 
 #include "Vector3.h"
 #include "Vector2.h"
+#include "Color.h"
 
 /// <summary>
 /// 4th Dimension Vector
@@ -72,6 +73,12 @@ public:
         return;
     }
 
+    inline Vector4(const Color& _color)
+    {
+        *this = _color.Vec4();
+        return;
+    }
+
     inline Vector3 xyz() { return Vector3(x, y, z); }
 
     inline Vector2 xy() { return Vector2(x, y); }
@@ -119,7 +126,7 @@ public:
     /// =======
     /// Vector3
     /// =======
-    
+
     Vector4& operator+=(const Vector3& _rv);
     Vector4& operator-=(const Vector3& _rv);
     Vector4& operator*=(const Vector3& _rv);

--- a/Math/impl/Color.cpp
+++ b/Math/impl/Color.cpp
@@ -1,0 +1,43 @@
+#include "Color.h"
+#include "Vector4.h"
+
+Color::Color(const Vector4& _vec4)
+{
+    rgba.r = static_cast<unsigned int>(_vec4.x * 255.0f);
+    rgba.g = static_cast<unsigned int>(_vec4.y * 255.0f);
+    rgba.b = static_cast<unsigned int>(_vec4.z * 255.0f);
+    rgba.a = static_cast<unsigned int>(_vec4.w * 255.0f);
+
+    return;
+}
+
+Color::Color(unsigned int _color)
+{
+    rgba.r = (_color >> 24) & 0xFF;
+    rgba.g = (_color >> 16) & 0xFF;
+    rgba.b = (_color >> 8) & 0xFF;
+    rgba.a = _color & 0xFF;
+
+    return;
+}
+
+Vector4 Color::Vec4() const
+{
+    return {
+        static_cast<float>(rgba.r) / 255.0f,
+        static_cast<float>(rgba.g) / 255.0f,
+        static_cast<float>(rgba.b) / 255.0f,
+        static_cast<float>(rgba.a) / 255.0f
+    };
+}
+
+unsigned int Color::UInt32() const
+{
+    unsigned int result = 0;
+    result |= rgba.r << 24;
+    result |= rgba.g << 16;
+    result |= rgba.b << 8;
+    result |= rgba.a;
+
+    return result;
+}


### PR DESCRIPTION
Vector4.hにColor.hをインクルードし、Vector4クラスにColorを引数とするコンストラクタを追加しました。また、Vector4クラスにoperator+=のVector3バージョンを追加しました。Color.hに#pragma onceを追加し、新しいColorクラスを定義しました。ColorクラスにはRGBA構造体、デフォルトコンストラクタ、Vector4を引数とするコンストラクタ、unsigned intを引数とするコンストラクタ、Vec4メソッド、UInt32メソッドを追加しました。Color.cppにColorクラスのメソッドの実装を追加しました。