### PR TITLE
前景スプライトとパーティクル描画の修正、カメラ設定追加

### DIFF
--- a/SampleProject/SampleProgram/SampleProgram.cpp
+++ b/SampleProject/SampleProgram/SampleProgram.cpp
@@ -61,13 +61,13 @@ void SampleProgram::Draw()
     pObject3dSystem_->PresentDraw();
     pSceneManager_->SceneDraw3d();
 
-
-    /// 前景スプライトの描画
-    // pSpriteSystem_->PresentDraw();
-    // pSceneManager_->SceneDraw2dForeground();
-
+    /// パーティクル描画
     pParticleSystem_->PresentDraw();
     pParticleManager_->Draw();
+
+    /// 前景スプライトの描画
+    pSpriteSystem_->PresentDraw();
+    pSceneManager_->SceneDraw2dForeground();
 
     pImGuiManager_->EndFrame();
     pDirectX_->PostDraw();

--- a/SampleProject/Scene/GameScene.cpp
+++ b/SampleProject/Scene/GameScene.cpp
@@ -14,6 +14,7 @@ void GameScene::Initialize()
     pGameEye_->SetTranslate({ 5.0f, 0.0f, -10.0f });
     pGameEye_->SetName("MainCamera");
 
+    /// システムにデフォルトのゲームカメラを設定
     Object3dSystem::GetInstance()->SetDefaultGameEye(pGameEye_);
     pParticleSystem_->SetDefaultGameEye(pGameEye_);
 
@@ -25,6 +26,7 @@ void GameScene::Initialize()
     pSpriteMB_->SetName("MonsterBall");
     pSpriteMB_->SetSize({ 120,60 });
     pSpriteMB_->SetPosition({ 40,60 });
+
     pSpriteUVC_->Initialize("uvChecker.png");
     pSpriteUVC_->SetName("uvChecker");
     pSpriteUVC_->SetSize({ 120,120 });
@@ -63,8 +65,6 @@ void GameScene::Draw2dBackGround()
 void GameScene::Draw3d()
 {
     pObject3d_->Draw();
-
-    pParticleSystem_->PresentDraw();
 }
 
 void GameScene::Draw2dForeground()

--- a/SampleProject/imgui.ini
+++ b/SampleProject/imgui.ini
@@ -66,3 +66,7 @@ Column 1  Weight=1.0000
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
+[Table][0xD91CAF56,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+


### PR DESCRIPTION
`SampleProgram.cpp` の `Draw()` メソッドで前景スプライトの描画を復活し、パーティクル描画を追加しました。`GameScene.cpp` の `Initialize()` メソッドでデフォルトのゲームカメラ設定と新しいスプライト `uvChecker` の初期化を追加しました。また、`Draw3d()` メソッドからパーティクルシステムの描画コードを削除しました。`imgui.ini` に新しいテーブル設定 `[Table][0xD91CAF56,2]` を追加しました。