### PR TITLE
UIの改善とパーティクルシステムの更新

### DIFF
--- a/Engine/Features/Particle/Emitter/BaseParticleEmitter.cpp
+++ b/Engine/Features/Particle/Emitter/BaseParticleEmitter.cpp
@@ -20,34 +20,52 @@ void BaseParticleEmitter::DebugWindow()
 {
 #ifdef _DEBUG
 
-    ImGui::DragFloat("発生間隔", &emitterData_.emitInterval_, 0.02f, 0.1f, FLT_MAX);
-
-    ImGui::InputInt("発生数", (int*)&emitterData_.emitNum_);
-    ImGui::Checkbox("ランダム範囲生成", &emitterData_.enableRandomEmit_);
-    if (emitterData_.enableRandomEmit_)
+    if (ImGui::CollapsingHeader("変形"))
     {
-        ImGui::DragFloat3("発生開始地点", &emitterData_.beginPosition_.x, 0.01f);
-        ImGui::DragFloat3("発生終了地点", &emitterData_.endPosition_.x, 0.01f);
-    }
-    else
-    {
-        ImGui::DragFloat3("発生位置", &emitterData_.emitPositionFixed_.x, 0.01f);
+        ImGui::DragFloat3("スケール", &emitterData_.scale_.x, 0.01f);
     }
 
-    ImGui::ColorEdit4("色", &emitterData_.color_.x);
-    ImGui::Checkbox("ランダム速度", &emitterData_.enableRandomVelocity_);
-    if (emitterData_.enableRandomVelocity_)
+    if (ImGui::CollapsingHeader("一般"))
     {
-        ImGui::DragFloat3("速度ランダム範囲開始", &emitterData_.velocityRandomRangeBegin_.x, 0.01f);
-        ImGui::DragFloat3("速度ランダム範囲終了", &emitterData_.velocityRandomRangeEnd_.x, 0.01f);
-    }
-    else
-    {
-        ImGui::DragFloat3("速度固定", &emitterData_.velocityFixed_.x, 0.01f);
+        ImGui::DragFloat("発生間隔", &emitterData_.emitInterval_, 0.02f, 0.1f, FLT_MAX);
+        ImGui::InputInt("発生数", (int*)&emitterData_.emitNum_);
+        ImGui::ColorEdit4("色", &emitterData_.color_.x);
+        ImGui::SliderFloat("透明度の変化量", &emitterData_.alphaDeltaValue_, -0.2f, 0.0f);
     }
 
-    ImGui::DragFloat3("重力", &emitterData_.gravity_.x, 0.01f);
-    ImGui::DragFloat3("抵抗", &emitterData_.resistance_.x, 0.01f);
+    if (ImGui::CollapsingHeader("生成場所"))
+    {
+        ImGui::Checkbox("ランダム範囲生成", &emitterData_.enableRandomEmit_);
+        if (emitterData_.enableRandomEmit_)
+        {
+            ImGui::DragFloat3("発生開始地点", &emitterData_.beginPosition_.x, 0.01f);
+            ImGui::DragFloat3("発生終了地点", &emitterData_.endPosition_.x, 0.01f);
+        }
+        else
+        {
+            ImGui::DragFloat3("発生位置", &emitterData_.emitPositionFixed_.x, 0.01f);
+        }
+    }
+
+    if (ImGui::CollapsingHeader("速度"))
+    {
+        ImGui::Checkbox("速度のランダマイズ", &emitterData_.enableRandomVelocity_);
+        if (emitterData_.enableRandomVelocity_)
+        {
+            ImGui::DragFloat3("速度ランダム範囲-開始", &emitterData_.velocityRandomRangeBegin_.x, 0.01f);
+            ImGui::DragFloat3("速度ランダム範囲-終了", &emitterData_.velocityRandomRangeEnd_.x, 0.01f);
+        }
+        else
+        {
+            ImGui::DragFloat3("速度", &emitterData_.velocityFixed_.x, 0.01f);
+        }
+    }
+
+    if (ImGui::CollapsingHeader("物理"))
+    {
+        ImGui::DragFloat3("重力", &emitterData_.gravity_.x, 0.01f);
+        ImGui::DragFloat3("抵抗", &emitterData_.resistance_.x, 0.01f);
+    }
 
 #endif // _DEBUG
 }

--- a/Engine/Features/Particle/Emitter/BaseParticleEmitter.h
+++ b/Engine/Features/Particle/Emitter/BaseParticleEmitter.h
@@ -14,6 +14,7 @@ struct EmitterData
     Vector3         emitPositionFixed_;             // ランダム発生しない場合の発生位置
     bool            enableRandomEmit_;              // ランダム発生
     Vector4         color_;                         // 色
+    float           alphaDeltaValue_;               // 透明度の変化量
     bool            enableRandomVelocity_;          // ランダム速度
     Vector3         velocityRandomRangeBegin_;      // 速度ランダム範囲
     Vector3         velocityRandomRangeEnd_;        // 速度ランダム範囲

--- a/Engine/Features/Particle/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Particle/Emitter/ParticleEmitter.cpp
@@ -79,7 +79,7 @@ void ParticleEmitter::EmitParticle()
     // 初期の色
     datum.color_ = emitterData_.color_;
     // アルファ値の変化量
-    datum.alphaDeltaValue_ = -0.01f;
+    datum.alphaDeltaValue_ = emitterData_.alphaDeltaValue_;
     // 消去条件
     datum.deleteCondition_ = ParticleDeleteCondition::ZeroAlpha;
     datum.accGravity_ = emitterData_.gravity_;

--- a/Engine/Features/Particle/Particle.cpp
+++ b/Engine/Features/Particle/Particle.cpp
@@ -67,6 +67,7 @@ void Particle::Update()
     while (true)
     {
         if (itr == particleData_.end()) break;
+        if (index >= currentInstancingSize_) break;
 
         Transform& transform = itr->transform_;
         Vector4& color = itr->color_;
@@ -141,6 +142,16 @@ void Particle::reserve(size_t _size)
     return;
 }
 
+void Particle::emplace_back(const ParticleData& _data)
+{
+    particleData_.emplace_back(_data);
+    if (particleData_.capacity() > currentInstancingSize_)
+    {
+        CreateParticleForGPUResource();
+        CreateSRV();
+    }
+}
+
 void Particle::CreateParticleForGPUResource()
 {
     /// 座標変換行列リソースを作成
@@ -154,6 +165,7 @@ void Particle::CreateParticleForGPUResource()
         instancingData_[index].world = Matrix4x4::Identity();
         instancingData_[index].color = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
     }
+    currentInstancingSize_ = static_cast<uint32_t>(particleData_.capacity());
 }
 
 void Particle::CreateSRV()

--- a/Engine/Features/Particle/Particle.h
+++ b/Engine/Features/Particle/Particle.h
@@ -55,7 +55,7 @@ public: /// Getter
 
 public: /// container operator
     void reserve(size_t _size);
-    void emplace_back(const ParticleData& _data) { particleData_.emplace_back(_data); }
+    void emplace_back(const ParticleData& _data);
 
 
 private:

--- a/SampleProject/Scene/GameScene/GameScene.cpp
+++ b/SampleProject/Scene/GameScene/GameScene.cpp
@@ -63,7 +63,7 @@ void GameScene::Finalize()
 
 void GameScene::Update()
 {
-    if (pInput_->TriggerKey(DIK_1))
+    if (pInput_->PushKey(DIK_LCONTROL) && pInput_->PushKey(DIK_1))
     {
         SceneManager::GetInstance()->ReserveScene("RequiredScene");
     }
@@ -101,6 +101,7 @@ void GameScene::EmitterSetting()
     emitterData.enableRandomEmit_ = false;
     emitterData.emitPositionFixed_ = Vector3(0.0f, 0.0f, 0.0f);
     emitterData.color_ = Vector4(0.8f, 0.35f, 0.15f, 1.0f);
+    emitterData.alphaDeltaValue_ = -0.01f;
     emitterData.emitterLifeTime_ = 0.0f;
     emitterData.enableRandomVelocity_ = true;
     emitterData.velocityRandomRangeBegin_ = Vector3(-2.0f, -0.0f, -0.0f);

--- a/SampleProject/Scene/RequiredScene/RequiredScene.cpp
+++ b/SampleProject/Scene/RequiredScene/RequiredScene.cpp
@@ -40,7 +40,7 @@ void RequiredScene::Update()
     pGameEye_->Update();
     pGuideSprite_->Update();
 
-    if (pInput_->TriggerKey(DIK_2))
+    if (pInput_->PushKey(DIK_LCONTROL) && pInput_->TriggerKey(DIK_2))
     {
         SceneManager::GetInstance()->ReserveScene("GameScene");
     }

--- a/SampleProject/imgui.ini
+++ b/SampleProject/imgui.ini
@@ -9,13 +9,13 @@ Size=1289,131
 Collapsed=0
 
 [Window][Objects]
-Pos=-2,131
+Pos=-2,132
 Size=177,459
 Collapsed=0
 
 [Window][デバッグ]
-Pos=877,33
-Size=391,430
+Pos=769,1
+Size=492,485
 Collapsed=0
 
 [Window][SRVManager]
@@ -196,6 +196,30 @@ Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
 [Table][0x49B338C2,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0xA72D0810,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0xF557748C,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x67732AE7,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x6A43D391,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0xF6826552,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x20092755,2]
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 


### PR DESCRIPTION
- `BaseParticleEmitter.cpp` の `DebugWindow` 関数で、ImGui の UI 要素を `CollapsingHeader` にグループ化し、UIの見通しを改善
- `BaseParticleEmitter.h` の `EmitterData` 構造体に `alphaDeltaValue_` を追加
- `ParticleEmitter.cpp` の `EmitParticle` 関数で、パーティクルのアルファ値の変化量を `emitterData_.alphaDeltaValue_` から設定
- `Particle.cpp` の `Update` 関数に `currentInstancingSize_` のチェックを追加し、`emplace_back` 関数を定義
- `Particle.h` で `emplace_back` 関数を宣言し、定義を `Particle.cpp` に移動
- `GameScene.cpp` と `RequiredScene.cpp` の `Finalize` 関数で、シーン切り替えのトリガーを `DIK_LCONTROL` と `DIK_1`/`DIK_2` の同時押しに変更
- `GameScene.cpp` の `EmitterSetting` 関数で、`emitterData.alphaDeltaValue_` を初期化
- `imgui.ini` のウィンドウ位置やサイズを変更し、テーブル設定を追加