### PR TITLE
カメラとマテリアルのスペキュラ反射を追加

### DIFF
--- a/Engine/EngineResources/Shaders/Object3d.VS.hlsl
+++ b/Engine/EngineResources/Shaders/Object3d.VS.hlsl
@@ -21,5 +21,6 @@ VertexShaderOutput main(VertexShaderInput input)
     output.position = mul(input.position, gTransformationMatrix.WVP);
     output.texcoord = input.texcoord;
     output.normal = normalize(mul(input.normal, (float3x3)gTransformationMatrix.World));
+    output.worldPosition = mul(input.position, gTransformationMatrix.World).xyz;
     return output;
 }

--- a/Engine/EngineResources/Shaders/Object3d.hlsli
+++ b/Engine/EngineResources/Shaders/Object3d.hlsli
@@ -3,5 +3,6 @@ struct VertexShaderOutput
     float4 position : SV_POSITION;
     float2 texcoord : TEXCOORD0;
     float3 normal : NORMAL0;
+    float3 worldPosition : POSITION0;
 };
 

--- a/Engine/Features/Model/Model.cpp
+++ b/Engine/Features/Model/Model.cpp
@@ -83,6 +83,7 @@ void Model::CreateMaterialResource()
     materialData_->color = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
     materialData_->enableLighting = isEnableLighting_;
     materialData_->uvTransform = Matrix4x4::Identity();
+    materialData_->shininess = 1.0f;
 }
 
 void Model::LoadModelTexture()

--- a/Engine/Features/Model/Model.h
+++ b/Engine/Features/Model/Model.h
@@ -30,6 +30,7 @@ public: /// Getter
     D3D12_VERTEX_BUFFER_VIEW GetVertexBufferView() const { return vertexBufferView_; }
     bool IsUploaded() const { return isUploaded_; }
     D3D12_GPU_DESCRIPTOR_HANDLE GetTextureSrvHandleGPU() const { return textureSrvHandleGPU_; }
+    Material* GetMaterialData() { return materialData_; }
 
 private: /// メンバ変数
     static const std::string kDefaultDirectoryPath;

--- a/Engine/Features/Object3d/Object3d.h
+++ b/Engine/Features/Object3d/Object3d.h
@@ -72,10 +72,15 @@ private: /// メンバ変数
     Microsoft::WRL::ComPtr<ID3D12Resource>          transformationMatrixResource_   = nullptr;
     Microsoft::WRL::ComPtr<ID3D12Resource>          directionalLightResource_       = nullptr;
     Microsoft::WRL::ComPtr<ID3D12Resource>          tilingResource_                 = nullptr;
+    Microsoft::WRL::ComPtr<ID3D12Resource>          cameraForGPUResource_           = nullptr;
 
     TransformationMatrix*                           transformationMatrixData_       = nullptr;
     DirectionalLight*                               directionalLight_               = nullptr;
     TilingData*                                     tilingData_                     = nullptr;
+    CameraForGPU*                                   cameraForGPU_                   = nullptr;
+
+    bool                                            isEnableLighting_               = true;
+
     Model*                                          pModel_                         = nullptr;
     std::string                                     modelPath_                      = {};
     GameEye*                                        pGameEye_                       = nullptr;
@@ -84,6 +89,7 @@ private: /// 非公開メンバ関数
     void CreateTransformationMatrixResource();
     void CreateDirectionalLightResource();
     void CreateTilingResource();
+    void CreateCameraForGPUResource();
 
 #ifdef DEBUG_ENGINE
     void DebugWindow();

--- a/Engine/Features/Object3d/Object3dSystem.cpp
+++ b/Engine/Features/Object3d/Object3dSystem.cpp
@@ -44,7 +44,7 @@ void Object3dSystem::CreateRootSignature()
         D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
 
     // RootParameter作成。複数設定できるので配列
-    D3D12_ROOT_PARAMETER rootParameters[5] = {};
+    D3D12_ROOT_PARAMETER rootParameters[6] = {};
     rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;                    // CBVを使う
     rootParameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;                 // PixelShaderで使う
     rootParameters[0].Descriptor.ShaderRegister = 0;                                    // レジスタ番号０とバインド
@@ -65,6 +65,10 @@ void Object3dSystem::CreateRootSignature()
     rootParameters[4].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;                    // CBVを使用する
     rootParameters[4].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;                 // PixelShaderで使用する
     rootParameters[4].Descriptor.ShaderRegister = 2;                                    // レジスタ番号2を使用する
+
+    rootParameters[5].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;                    // CBVを使用する
+    rootParameters[5].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;                 // PixelShaderで使用する
+    rootParameters[5].Descriptor.ShaderRegister = 3;                                    // レジスタ番号3を使用する
 
 
     descriptionRootSignature.pParameters = rootParameters;                              // ルートパラメータ配列へのポインタ
@@ -127,6 +131,7 @@ void Object3dSystem::CreatePipelineState()
     inputElementDescs[2].SemanticIndex = 0;
     inputElementDescs[2].Format = DXGI_FORMAT_R32G32B32_FLOAT;
     inputElementDescs[2].AlignedByteOffset = D3D12_APPEND_ALIGNED_ELEMENT;
+
 
     D3D12_INPUT_LAYOUT_DESC inputLayoutDesc{};
     inputLayoutDesc.pInputElementDescs = inputElementDescs;

--- a/Engine/Features/Object3d/Object3dSystem.h
+++ b/Engine/Features/Object3d/Object3dSystem.h
@@ -12,6 +12,12 @@ struct Material
     int32_t enableLighting;
     float padding[2];
     Matrix4x4 uvTransform;
+    float shininess;
+};
+
+struct CameraForGPU
+{
+    Vector3 worldPosition;
 };
 
 /// <summary>

--- a/SampleProject/EngineResources/Shaders/Object3d.VS.hlsl
+++ b/SampleProject/EngineResources/Shaders/Object3d.VS.hlsl
@@ -21,5 +21,6 @@ VertexShaderOutput main(VertexShaderInput input)
     output.position = mul(input.position, gTransformationMatrix.WVP);
     output.texcoord = input.texcoord;
     output.normal = normalize(mul(input.normal, (float3x3)gTransformationMatrix.World));
+    output.worldPosition = mul(input.position, gTransformationMatrix.World).xyz;
     return output;
 }

--- a/SampleProject/EngineResources/Shaders/Object3d.hlsli
+++ b/SampleProject/EngineResources/Shaders/Object3d.hlsli
@@ -3,5 +3,6 @@ struct VertexShaderOutput
     float4 position : SV_POSITION;
     float2 texcoord : TEXCOORD0;
     float3 normal : NORMAL0;
+    float3 worldPosition : POSITION0;
 };
 

--- a/SampleProject/imgui.ini
+++ b/SampleProject/imgui.ini
@@ -14,8 +14,8 @@ Size=177,722
 Collapsed=0
 
 [Window][デバッグ]
-Pos=229,174
-Size=1073,203
+Pos=245,194
+Size=611,318
 Collapsed=0
 
 [Window][SRVManager]


### PR DESCRIPTION
`Object3d.PS.hlsl`に`Camera`構造体と`shininess`フィールドを追加し、スペキュラ反射の計算を実装しました。`Object3d.VS.hlsl`と`Object3d.hlsli`に頂点のワールド座標を追加しました。`Model.cpp`と`Model.h`にマテリアルデータの初期化と取得関数を追加しました。`Object3d.cpp`にカメラのワールド座標リソースの作成、更新、設定処理を追加し、ライティングの有効/無効を切り替えるチェックボックスを追加しました。`Object3dSystem.cpp`と`Object3dSystem.h`にカメラのワールド座標リソースのルートパラメータと構造体を追加しました。`imgui.ini`でデバッグウィンドウの位置とサイズを変更しました。