### PR TITLE
プロジェクト設定の更新とサブプロジェクトのコミットID変更

### DIFF
--- a/Engine/Externals/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj
+++ b/Engine/Externals/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj
@@ -44,12 +44,14 @@
     <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTex</TargetName>
     <GenerateManifest>true</GenerateManifest>
+    <PublicIncludeDirectories>$(ProjectDir)</PublicIncludeDirectories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
     <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTex</TargetName>
     <GenerateManifest>true</GenerateManifest>
+    <PublicIncludeDirectories>$(ProjectDir)</PublicIncludeDirectories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
     <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>


### PR DESCRIPTION
DirectXTex_Desktop_2022_Win10.vcxprojファイルにおいて、Debug|X64およびRelease|X64の構成に対して、<PublicIncludeDirectories>$(ProjectDir)</PublicIncludeDirectories>が追加されました。 VectorMatrixサブプロジェクトのコミットIDが8d26d84cce20f40f24b70f2a4c241b4d56f2d81fから8d26d84cce20f40f24b70f2a4c241b4d56f2d81f-dirtyに変更されました。