### PR TITLE
`pFirework_`のモデルファイルを変更

### DIFF
--- a/SampleProject/Scene/GameScene/GameScene.cpp
+++ b/SampleProject/Scene/GameScene/GameScene.cpp
@@ -50,7 +50,7 @@ void GameScene::Initialize()
     pGrid_->SetEnableLighting(false);
 
     /// エミッタの初期化
-    pFirework_->Initialize("Particle/ParticleSpark.obj", "Resources/Json/Firework.json");
+    pFirework_->Initialize("Triangle/Triangle.obj", "Resources/Json/Firework.json");
     pSmoke_->Initialize("Particle/ParticleSpark.obj", "Resources/Json/Smoke.json");
     pSpark_->Initialize("Particle/ParticleSpark.obj", "Resources/Json/Spark.json");
 }


### PR DESCRIPTION
## GameSceneクラス

### 変更内容
- `GameScene::Initialize()` メソッド内で、`pFirework_` の初期化に使用するモデルファイルを変更
  - 以前: `"Particle/ParticleSpark.obj"`
  - 変更後: `"Triangle/Triangle.obj"`

### バイナリファイルの変更
- モデルファイルの変更に伴い、`Triangle/Triangle.obj` を新たに使用