### PR TITLE
DirectX12, DX12Helper, Modelの修正と設定の更新

### DIFF
--- a/Engine/Core/DirectX12/DirectX12.cpp
+++ b/Engine/Core/DirectX12/DirectX12.cpp
@@ -272,7 +272,6 @@ DirectX12::~DirectX12()
         fence->SetEventOnCompletion(fenceSignalValue, fenceEvent_);
         WaitForSingleObject(fenceEvent_, INFINITE);
     }
-    auto ref = device_->Release();
 
     pSRVManager_->Deallocate(gameWndSrvIndex_);
 }

--- a/Engine/Core/DirectX12/DirectX12.h
+++ b/Engine/Core/DirectX12/DirectX12.h
@@ -104,7 +104,6 @@ private:
     std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>                srvHandlesGPUList_              = {};           // SRVハンドルリスト(GPU)
     std::vector<D3D12_CPU_DESCRIPTOR_HANDLE>                srvHandlesCPUList_              = {};           // SRVハンドルリスト(CPU)
     std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>>     textureResources_               = {};           // テクスチャリソース
-    Microsoft::WRL::ComPtr<ID3D12Device>                    device_                         = nullptr;      // デバイス
     Microsoft::WRL::ComPtr<ID3D12Debug1>                    debugController_                = nullptr;      // デバッグコントローラ
     Microsoft::WRL::ComPtr<IDXGIFactory7>                   dxgiFactory_                    = nullptr;      // DXGIファクトリ
     Microsoft::WRL::ComPtr<IDXGIAdapter4>                   useAdapter_                     = nullptr;      // 使うアダプタ
@@ -132,6 +131,7 @@ private:
     Microsoft::WRL::ComPtr<IDXGIDevice>                     dxgiDevice_                     = nullptr;      // DXGIデバイス
     Microsoft::WRL::ComPtr<ID2D1Device2>                    d2dDevice_                      = nullptr;      // d2d1デバイス
     Microsoft::WRL::ComPtr<ID2D1DeviceContext2>             d2dDeviceContext_               = nullptr;      // d2d1デバイスコンテキスト
+    Microsoft::WRL::ComPtr<ID3D12Device>                    device_                         = nullptr;      // デバイス
 
     std::array<Microsoft::WRL::ComPtr<ID3D11Resource>, 2>   d3d11WrappedBackBuffers_        = {};           // D3D11のラップされたバックバッファ
     std::array<Microsoft::WRL::ComPtr<ID2D1Bitmap1>, 2>     d2dRenderTargets_               = {};           // D2D1のレンダーターゲット

--- a/Engine/Core/DirectX12/Helper/DX12Helper.cpp
+++ b/Engine/Core/DirectX12/Helper/DX12Helper.cpp
@@ -406,7 +406,7 @@ void DX12Helper::CreateNewTexture(const Microsoft::WRL::ComPtr<ID3D12Device>& _d
     return;
 }
 
-Microsoft::WRL::ComPtr<ID3D12Resource> DX12Helper::CreateVertexResource(const Microsoft::WRL::ComPtr<ID3D12Device> _device, unsigned int _countVertex)
+Microsoft::WRL::ComPtr<ID3D12Resource> DX12Helper::CreateVertexResource(const Microsoft::WRL::ComPtr<ID3D12Device>& _device, unsigned int _countVertex)
 {
     // 頂点リソースを作る
     Microsoft::WRL::ComPtr<ID3D12Resource> vertexResource = CreateBufferResource(_device, sizeof(VertexData) * _countVertex);

--- a/Engine/Core/DirectX12/Helper/DX12Helper.h
+++ b/Engine/Core/DirectX12/Helper/DX12Helper.h
@@ -17,7 +17,6 @@ namespace DX12Helper
     /// <param name="_device">生成先</param>
     /// <param name="_adapter">使用するアダプタ</param>
     void CreateDevice(Microsoft::WRL::ComPtr<ID3D12Device>& _device, Microsoft::WRL::ComPtr<IDXGIAdapter4>& _adapter);
-    //void CreateDevice(ID3D12Device** _device, Microsoft::WRL::ComPtr<IDXGIAdapter4>& _adapter);
 
 
     /// <summary>
@@ -110,7 +109,7 @@ namespace DX12Helper
     /// 頂点リソースを生成
     /// </summary>
     /// <param name="_device">デバイス</param>
-    Microsoft::WRL::ComPtr<ID3D12Resource> CreateVertexResource(const Microsoft::WRL::ComPtr<ID3D12Device> _device, unsigned int _countVertex);
+    Microsoft::WRL::ComPtr<ID3D12Resource> CreateVertexResource(const Microsoft::WRL::ComPtr<ID3D12Device>& _device, unsigned int _countVertex);
 
     void ChangeStateResource(
         const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& _commandList, 

--- a/Engine/Features/Model/Model.cpp
+++ b/Engine/Features/Model/Model.cpp
@@ -17,7 +17,7 @@ void Model::Initialize(const std::string& _filePath)
     filePath_ = _filePath;
 
     /// モデルデータを読み込む
-    th_LoadObjectFile_ = std::thread([&](){
+    th_LoadObjectFile_ = std::make_unique<std::thread>([&](){
 
         directoryPath_ = ModelManager::GetInstance()->GetDirectoryPath(filePath_);
         modelData_ = ModelHelper::LoadObjFile(directoryPath_, filePath_);
@@ -32,7 +32,7 @@ void Model::Update()
 
 void Model::Draw()
 {
-    if (th_LoadObjectFile_.joinable()) return;
+    if (th_LoadObjectFile_->joinable()) return;
     ID3D12GraphicsCommandList* commandList = pDx12_->GetCommandList();
 
     // 頂点バッファを設定
@@ -46,7 +46,7 @@ void Model::Draw()
 Model::~Model()
 {
     OutputDebugStringA("Model Destructor\n");
-    if (th_LoadObjectFile_.joinable()) th_LoadObjectFile_.join();
+    if (th_LoadObjectFile_->joinable()) th_LoadObjectFile_->join();
 }
 
 void Model::CreateVertexResource()
@@ -82,9 +82,9 @@ void Model::LoadModelTexture()
 
 void Model::Upload()
 {
-    if (th_LoadObjectFile_.joinable())
+    if (th_LoadObjectFile_ && th_LoadObjectFile_->joinable())
     {
-        th_LoadObjectFile_.join();
+        th_LoadObjectFile_->join();
     }
 
     /// 頂点リソースを作成

--- a/Engine/Features/Model/Model.h
+++ b/Engine/Features/Model/Model.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <Core/DirectX12/DirectX12.h>
 #include <thread>
+#include <memory>
 
 
 struct Material;
@@ -47,7 +48,7 @@ private: /// 非公開メンバ関数
 private: /// 他クラスのインスタンス
     DirectX12* pDx12_ = nullptr;
     ID3D12Device* device_ = nullptr;
-    std::thread th_LoadObjectFile_ = {};
+    std::unique_ptr<std::thread> th_LoadObjectFile_ = nullptr;
     std::string filePath_;
     std::string directoryPath_;
 };

--- a/SampleProject/Resources/Json/Spark.json
+++ b/SampleProject/Resources/Json/Spark.json
@@ -1,34 +1,18 @@
 {
-    "alphaDeltaValue" : 0.000000,
-    "beginColor" : {
-        "a" : 1.000000,
-        "b" : 0.749020,
-        "g" : 0.976471,
-        "r" : 0.976471
-    },
-    "beginPosition" : {
-        "x" : 0.000000,
-        "y" : 0.000000,
-        "z" : 0.000000
-    },
-    "emitInterval" : 0.050000,
-    "emitNum" : 7,
-    "emitPositionFixed" : {
-        "x" : 1.000000,
-        "y" : 0.000000,
-        "z" : 0.000000
-    },
     "emitterLifeTime" : 2.000000,
     "emitterName" : "Spark",
-    "enableRandomEmit" : false,
-    "enableRandomVelocity" : true,
-    "endColor" : {
-        "a" : 0.000000,
-        "b" : 0.149020,
-        "g" : 0.474510,
-        "r" : 0.976471
+    "emitInterval" : 0.050000,
+    "velocityRandomRangeBegin" : {
+        "x" : -0.500000,
+        "y" : -0.500000,
+        "z" : -0.500000
     },
-    "endPosition" : {
+    "startScale" : {
+        "x" : 0.050000,
+        "y" : 0.050000,
+        "z" : 0.050000
+    },
+    "resistance" : {
         "x" : 0.000000,
         "y" : 0.000000,
         "z" : 0.000000
@@ -43,31 +27,47 @@
         "y" : 0.000000,
         "z" : 0.000000
     },
+    "scaleDelayTime" : 0.000000,
     "particleLifeTime" : 2.500000,
-    "resistance" : {
+    "emitNum" : 7,
+    "enableRandomEmit" : false,
+    "beginPosition" : {
         "x" : 0.000000,
         "y" : 0.000000,
         "z" : 0.000000
     },
-    "scaleDelayTime" : 0.000000,
-    "startScale" : {
-        "x" : 0.050000,
-        "y" : 0.050000,
-        "z" : 0.050000
+    "endPosition" : {
+        "x" : 0.000000,
+        "y" : 0.000000,
+        "z" : 0.000000
+    },
+    "emitPositionFixed" : {
+        "x" : 1.000000,
+        "y" : 0.000000,
+        "z" : 0.000000
+    },
+    "enableRandomVelocity" : true,
+    "velocityRandomRangeEnd" : {
+        "x" : 0.500000,
+        "y" : 0.500000,
+        "z" : 0.500000
     },
     "velocityFixed" : {
         "x" : 0.000000,
         "y" : 1.000000,
         "z" : 0.000000
     },
-    "velocityRandomRangeBegin" : {
-        "x" : -0.500000,
-        "y" : -0.500000,
-        "z" : -0.500000
+    "beginColor" : {
+        "r" : 0.976471,
+        "b" : 0.749020,
+        "g" : 0.976471,
+        "a" : 1.000000
     },
-    "velocityRandomRangeEnd" : {
-        "x" : 0.500000,
-        "y" : 0.500000,
-        "z" : 0.500000
-    }
+    "endColor" : {
+        "r" : 0.976471,
+        "b" : 0.149020,
+        "g" : 0.474510,
+        "a" : 0.000000
+    },
+    "alphaDeltaValue" : 0.000000
 }

--- a/SampleProject/imgui.ini
+++ b/SampleProject/imgui.ini
@@ -437,6 +437,14 @@ Column 1  Weight=1.0000
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
+[Table][0x0F1C5A8A,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x3D152174,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
 [Docking][Data]
 DockSpace       ID=0xD5ACB325 Window=0xA87D555D Pos=0,0 Size=32,32 Split=X
   DockNode      ID=0x00000005 Parent=0xD5ACB325 SizeRef=1259,900 Split=X


### PR DESCRIPTION
## DirectX12
- `DirectX12.cpp` の `DirectX12::~DirectX12()` において、`device_->Release()` の呼び出しを削除。
- `DirectX12.h` の `private:` セクションにおいて、`Microsoft::WRL::ComPtr<ID3D12Device> device_` を削除し、再度追加。

## DX12Helper
- `DX12Helper.cpp` の `DX12Helper::CreateVertexResource` メソッドの引数 `_device` を参照渡しに変更。
- `DX12Helper.h` の `namespace DX12Helper` 内で、`CreateVertexResource` メソッドの引数 `_device` を参照渡しに変更。

## Model
- `Model.cpp` の `Model::Initialize` メソッドにおいて、`th_LoadObjectFile_` を `std::thread` から `std::make_unique<std::thread>` に変更。
- `Model.cpp` の `Model::Draw` メソッドにおいて、`th_LoadObjectFile_` の `joinable()` チェックをポインタを考慮したものに変更。
- `Model.cpp` の `Model::~Model` メソッドにおいて、`th_LoadObjectFile_` の `joinable()` チェックをポインタを考慮したものに変更。
- `Model.cpp` の `Model::Upload` メソッドにおいて、`th_LoadObjectFile_` の `joinable()` チェックをポインタを考慮したものに変更。
- `Model.h` に `#include <memory>` を追加。
- `Model.h` の `private:` セクションにおいて、`th_LoadObjectFile_` を `std::thread` から `std::unique_ptr<std::thread>` に変更。

## 設定ファイル
- `Spark.json` において、いくつかのプロパティが削除され、新しいプロパティが追加。
- `imgui.ini` に新しいテーブル設定を追加。