### PR TITLE
フレームレート計算の改善とDepthSceneの追加

### DIFF
--- a/Engine/Core/DirectX12/DirectX12.cpp
+++ b/Engine/Core/DirectX12/DirectX12.cpp
@@ -195,7 +195,7 @@ void DirectX12::PostDraw()
 
 
     /// フレームレート固定
-    pFramerate_->FixFramerate();
+    //pFramerate_->FixFramerate();
 
 
     /// 次のフレーム用のコマンドリストを準備

--- a/Engine/DebugTools/DebugManager/DebugManager.cpp
+++ b/Engine/DebugTools/DebugManager/DebugManager.cpp
@@ -24,7 +24,7 @@ void DebugManager::DebugWindowOverall() const
 
     const float PAD = 10.0f;
     const ImGuiViewport* viewport = ImGui::GetMainViewport();
-    ImVec2 work_pos = viewport->WorkPos; // Use work area to avoid menu-bar/task-bar, if any!
+    ImVec2 work_pos = viewport->WorkPos;
     ImVec2 work_size = viewport->WorkSize;
     ImVec2 window_pos, window_pos_pivot;
     window_pos.x = PAD;
@@ -55,7 +55,7 @@ void DebugManager::MeasureFPS()
         timer_.Start();
     }
     /// フレームレート計算
-    if (timer_.GetNow() - elapsedFrameCount_ >= 2.0)
+    if (timer_.GetNow() - elapsedFrameCount_ >= 0.1)
     {
         fps_ = frameCount_ * 1.0 / (timer_.GetNow() - elapsedFrameCount_);
 
@@ -200,7 +200,7 @@ void DebugManager::DrawUI()
 
     MeasureFPS();
 
-    //DebugWindowOverall();
+    DebugWindowOverall();
 
     Window_Log();
 

--- a/Engine/Features/Model/Model.cpp
+++ b/Engine/Features/Model/Model.cpp
@@ -17,8 +17,8 @@ void Model::Initialize(const std::string& _filePath)
     filePath_ = _filePath;
 
     /// モデルデータを読み込む
-    th_LoadObjectFile_ = std::make_unique<std::thread>([&](){
-
+    th_LoadObjectFile_ = std::make_unique<std::thread>([&]()
+    {
         directoryPath_ = ModelManager::GetInstance()->GetDirectoryPath(filePath_);
         modelData_ = ModelHelper::LoadObjFile(directoryPath_, filePath_);
         ModelManager::GetInstance()->InqueueUpload(this);

--- a/Engine/Interfaces/IScene.h
+++ b/Engine/Interfaces/IScene.h
@@ -57,3 +57,44 @@ public:
     /// </summary>
     virtual void DrawTexts() = 0;
 };
+
+#define NEW_SCENE_IMPL(class)\
+void class::Initialize()\
+{\
+}\
+\
+void class::Finalize()\
+{\
+}\
+\
+void class::Update()\
+{\
+}\
+\
+void class::Draw2dBackGround()\
+{\
+}\
+\
+void class::Draw3d()\
+{\
+}\
+\
+void class::Draw2dMidground()\
+{\
+}\
+\
+void class::Draw3dMidground()\
+{\
+}\
+\
+void class::DrawLine()\
+{\
+}\
+\
+void class::Draw2dForeground()\
+{\
+}\
+\
+void class::DrawTexts()\
+{\
+}\

--- a/SampleProject/SampleProgram/SampleProgram.cpp
+++ b/SampleProject/SampleProgram/SampleProgram.cpp
@@ -82,7 +82,7 @@ void SampleProgram::Draw()
     pSpriteSystem_->PresentDraw();
     pSceneManager_->SceneDraw2dForeground();
 
-    pDirectX_->CopyFromRTV();
+    //pDirectX_->CopyFromRTV();
     //pViewport_->Compute();
 
     pImGuiManager_->EndFrame();

--- a/SampleProject/SampleProject.vcxproj
+++ b/SampleProject/SampleProject.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -118,6 +118,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="main.cpp" />
     <ClCompile Include="SampleProgram\SampleProgram.cpp" />
     <ClCompile Include="Scene\CG3PT2\CG3PT2.cpp" />
+    <ClCompile Include="Scene\DepthScene\DepthScene.cpp" />
     <ClCompile Include="Scene\Empty\EmptyScene.cpp" />
     <ClCompile Include="Scene\Factory\SceneFactory.cpp" />
     <ClCompile Include="Scene\GameScene\GameScene.cpp" />
@@ -137,6 +138,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
   <ItemGroup>
     <ClInclude Include="SampleProgram\SampleProgram.h" />
     <ClInclude Include="Scene\CG3PT2\CG3PT2.h" />
+    <ClInclude Include="Scene\DepthScene\DepthScene.h" />
     <ClInclude Include="Scene\Empty\EmptyScene.h" />
     <ClInclude Include="Scene\Factory\SceneFactory.h" />
     <ClInclude Include="Scene\GameScene\GameScene.h" />

--- a/SampleProject/SampleProject.vcxproj.filters
+++ b/SampleProject/SampleProject.vcxproj.filters
@@ -34,6 +34,9 @@
     <Filter Include="Game\Scene\Empty">
       <UniqueIdentifier>{352d90bb-cc55-43d0-b199-e968f7902539}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Game\Scene\DepthScene">
+      <UniqueIdentifier>{530a3488-5a08-450e-a0e5-1a76324cded4}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -57,6 +60,9 @@
     <ClCompile Include="Scene\Empty\EmptyScene.cpp">
       <Filter>Game\Scene\Empty</Filter>
     </ClCompile>
+    <ClCompile Include="Scene\DepthScene\DepthScene.cpp">
+      <Filter>Game\Scene\DepthScene</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SampleProgram\SampleProgram.h">
@@ -76,6 +82,9 @@
     </ClInclude>
     <ClInclude Include="Scene\Empty\EmptyScene.h">
       <Filter>Game\Scene\Empty</Filter>
+    </ClInclude>
+    <ClInclude Include="Scene\DepthScene\DepthScene.h">
+      <Filter>Game\Scene\DepthScene</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/SampleProject/Scene/DepthScene/DepthScene.cpp
+++ b/SampleProject/Scene/DepthScene/DepthScene.cpp
@@ -1,0 +1,100 @@
+#include "DepthScene.h"
+
+#include <DebugTools/DebugManager/DebugManager.h>
+#include <imgui.h>
+
+void DepthScene::Initialize()
+{
+    pInput_ = Input::GetInstance();
+    DebugManager::GetInstance()->SetComponent("Scene", windowName_, std::bind(&DepthScene::DebugWindow, this));
+
+    pGameEye_ = std::make_unique<GameEye>();
+    pGameEye_->SetName("DepthScene_Camera");
+    pGameEye_->SetTranslate(Vector3(0.0f, 0.0f, -10.0f));
+
+    CreateObject();
+}
+
+void DepthScene::Finalize()
+{
+    objectList_.clear();
+
+    DebugManager::GetInstance()->DeleteComponent("Scene", windowName_.c_str());
+}
+
+void DepthScene::Update()
+{
+    if ( pInput_->TriggerKey(DIK_RETURN) )
+    {
+        CreateObject();
+    }
+
+    if ( nextCreateCount_ > 0 )
+    {
+        CreateObject();
+        nextCreateCount_--;
+    }
+
+    for ( auto& obj : objectList_ )
+    {
+        obj->Update();
+    }
+
+    pGameEye_->Update();
+}
+
+void DepthScene::Draw2dBackGround()
+{
+}
+
+void DepthScene::Draw3d()
+{
+    for ( auto& obj : objectList_ )
+    {
+        obj->Draw();
+    }
+}
+
+void DepthScene::Draw2dMidground()
+{
+}
+
+void DepthScene::Draw3dMidground()
+{
+}
+
+void DepthScene::DrawLine()
+{
+}
+
+void DepthScene::Draw2dForeground()
+{
+}
+
+void DepthScene::DrawTexts()
+{
+}
+
+void DepthScene::CreateObject()
+{
+    objectList_.push_back(std::make_unique<Object3d>());
+    Object3d* obj = objectList_.back().get();
+    obj->Initialize("plane.obj");
+    obj->SetTranslate(Vector3(0.0f, 0.0f, nextObjZ_));
+    obj->SetGameEye(pGameEye_.get());
+    nextObjZ_ += objZInterval_;
+}
+
+void DepthScene::DebugWindow()
+{
+    ImGui::Text("Object count : %d", objectList_.size());
+
+    /// 一括作成の個数の入力
+    ImGui::InputInt("Create Count", &nextCreateCountTemp_);
+
+    /// 一括作成の実行
+    if ( ImGui::Button("Create") )
+    {
+        nextCreateCount_ = nextCreateCountTemp_;
+    }
+}

--- a/SampleProject/Scene/DepthScene/DepthScene.h
+++ b/SampleProject/Scene/DepthScene/DepthScene.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <Interfaces/IScene.h>
+#include <Features/Object3d/Object3d.h>
+#include <Features/Input/Input.h>
+#include <Features/GameEye/GameEye.h>
+
+#include <list>
+#include <memory>
+
+class DepthScene : public IScene
+{
+public:
+    DepthScene() = default;
+    ~DepthScene() = default;
+
+    void Initialize() override;
+    void Finalize() override;
+    void Update() override;
+    void Draw2dBackGround() override;
+    void Draw3d() override;
+    void Draw2dMidground() override;
+    void Draw3dMidground() override;
+    void DrawLine() override;
+    void Draw2dForeground() override;
+    void DrawTexts() override;
+
+private:
+    std::unique_ptr<GameEye> pGameEye_ = nullptr;
+    std::list<std::unique_ptr<Object3d>> objectList_;
+    float nextObjZ_ = 0;
+    const float objZInterval_ = 0.01f;
+    unsigned int nextCreateCount_ = 0;
+    int nextCreateCountTemp_ = 0;
+
+private:
+    Input* pInput_ = nullptr;
+
+private:
+    void CreateObject();
+    void DebugWindow();
+    std::string windowName_ = "DepthScene";
+};

--- a/SampleProject/Scene/Empty/EmptyScene.cpp
+++ b/SampleProject/Scene/Empty/EmptyScene.cpp
@@ -35,3 +35,7 @@ void EmptyScene::DrawLine()
 void EmptyScene::Draw2dForeground()
 {
 }
+
+void EmptyScene::DrawTexts()
+{
+}

--- a/SampleProject/Scene/Empty/EmptyScene.h
+++ b/SampleProject/Scene/Empty/EmptyScene.h
@@ -17,6 +17,7 @@ public:
     void Draw3dMidground() override;
     void DrawLine() override;
     void Draw2dForeground() override;
+    void DrawTexts() override;
 
 private:
 };

--- a/SampleProject/Scene/Factory/SceneFactory.cpp
+++ b/SampleProject/Scene/Factory/SceneFactory.cpp
@@ -3,6 +3,7 @@
 #include <Scene/GameScene/GameScene.h>
 #include <Scene/InstancingScene/InstancingScene.h>
 #include <Scene/CG3PT2/CG3PT2.h>
+#include <Scene/DepthScene/DepthScene.h>
 
 #include <cassert>
 
@@ -13,6 +14,7 @@ std::unique_ptr<IScene> SceneFactory::CreateScene(const std::string & _sceneName
     JUDGE_SCENE(InstancingScene)
     else JUDGE_SCENE(GameScene)
     else JUDGE_SCENE(CG3PT2)
+    else JUDGE_SCENE(DepthScene)
 
     assert(false && "シーンの生成に失敗しました");
 

--- a/SampleProject/imgui.ini
+++ b/SampleProject/imgui.ini
@@ -4,20 +4,20 @@ Size=756,957
 Collapsed=0
 
 [Window][Log]
-Pos=0,654
-Size=1120,246
+Pos=0,17
+Size=15,27
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Objects]
-Pos=1122,0
-Size=137,900
+Pos=17,0
+Size=6,32
 Collapsed=0
-DockId=0x00000004,0
+DockId=0x00000005,0
 
 [Window][デバッグ]
-Pos=1261,0
-Size=339,900
+Pos=25,0
+Size=7,32
 Collapsed=0
 DockId=0x00000006,0
 
@@ -27,18 +27,18 @@ Size=373,177
 Collapsed=0
 
 [Window][GameWindow]
-Size=6,27
+Size=15,27
 Collapsed=0
 DockId=0x00000001,0
 
 [Window][SceneManager]
-Pos=303,529
-Size=571,63
+Pos=581,493
+Size=571,62
 Collapsed=0
 
 [Window][WindowOverViewport_11111111]
 Pos=0,0
-Size=1600,900
+Size=32,32
 Collapsed=0
 
 [Table][0x3DFC7327,2]
@@ -446,11 +446,11 @@ Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
 [Docking][Data]
-DockSpace       ID=0xD5ACB325 Window=0xA87D555D Pos=0,0 Size=1600,900 Split=X
-  DockNode      ID=0x00000005 Parent=0xD5ACB325 SizeRef=1259,900 Split=X
-    DockNode    ID=0x00000003 Parent=0x00000005 SizeRef=1120,900 Split=Y
-      DockNode  ID=0x00000001 Parent=0x00000003 SizeRef=1600,652 CentralNode=1 Selected=0xBA965914
-      DockNode  ID=0x00000002 Parent=0x00000003 SizeRef=1600,246 Selected=0x64F50EE5
-    DockNode    ID=0x00000004 Parent=0x00000005 SizeRef=137,900 Selected=0x967E7699
-  DockNode      ID=0x00000006 Parent=0xD5ACB325 SizeRef=339,900 Selected=0x435A4E3F
+DockSpace     ID=0xD5ACB325 Window=0xA87D555D Pos=0,0 Size=32,32 Split=X
+  DockNode    ID=0x00000003 Parent=0xD5ACB325 SizeRef=1143,900 Split=Y
+    DockNode  ID=0x00000001 Parent=0x00000003 SizeRef=1600,652 CentralNode=1 Selected=0xBA965914
+    DockNode  ID=0x00000002 Parent=0x00000003 SizeRef=1600,246 Selected=0x64F50EE5
+  DockNode    ID=0x00000004 Parent=0xD5ACB325 SizeRef=455,900 Split=X Selected=0x435A4E3F
+    DockNode  ID=0x00000005 Parent=0x00000004 SizeRef=127,900 Selected=0x967E7699
+    DockNode  ID=0x00000006 Parent=0x00000004 SizeRef=326,900 Selected=0x435A4E3F
 


### PR DESCRIPTION
## DirectX12
- `DirectX12.cpp` の `void DirectX12::PostDraw()` メソッドで、フレームレート固定のコードをコメントアウト

## DebugManager
- `DebugManager.cpp` の `void DebugManager::DebugWindowOverall() const` メソッドで、メニュー・タスクバーを避けるためのコメントを削除
- `DebugManager.cpp` の `void DebugManager::MeasureFPS()` メソッドで、フレームレート計算の間隔を2.0秒から0.1秒に変更
- `DebugManager.cpp` の `void DebugManager::DrawUI()` メソッドで、`DebugWindowOverall()` メソッドの呼び出しを有効化

## Model
- `Model.cpp` の `void Model::Initialize(const std::string& _filePath)` メソッドで、モデルデータを読み込むスレッドのラムダ式の位置を変更

## IScene
- `IScene.h` に `NEW_SCENE_IMPL` マクロを追加

## SampleProgram
- `SampleProgram.cpp` の `void SampleProgram::Draw()` メソッドで、`pDirectX_->CopyFromRTV()` の呼び出しをコメントアウト

## SampleProject
- `SampleProject.vcxproj` に `Scene\DepthScene\DepthScene.cpp` と `Scene\DepthScene\DepthScene.h` を追加
- `SampleProject.vcxproj.filters` に `Game\Scene\DepthScene` フィルターを追加し、`Scene\DepthScene\DepthScene.cpp` と `Scene\DepthScene\DepthScene.h` をそのフィルターに含める

## EmptyScene
- `EmptyScene.cpp` に `void EmptyScene::DrawTexts()` メソッドを追加
- `EmptyScene.h` に `void DrawTexts() override;` を追加

## SceneFactory
- `SceneFactory.cpp` に `#include <Scene/DepthScene/DepthScene.h>` を追加し、`DepthScene` のシーン生成を可能に

## imgui
- `imgui.ini` のウィンドウ位置とサイズを変更

## DepthScene
- `DepthScene.cpp` と `DepthScene.h` を新たに追加し、`DepthScene` クラスを定義。このクラスには、シーンの初期化、更新、描画、デバッグウィンドウの表示などのメソッドが含まれる