### PR TITLE
モデルマネージャーに自動ロードパスを追加

### DIFF
--- a/SampleProject/SampleProgram/SampleProgram.cpp
+++ b/SampleProject/SampleProgram/SampleProgram.cpp
@@ -15,6 +15,7 @@ void SampleProgram::Initialize()
     pSceneManager_->SetSceneFactory(pSceneFactory_.get());
 
     /// 自動ロードパスの追加
+    pModelManager_->AddAutoLoadPath("resources/models");
     pModelManager_->AddAutoLoadPath("resources/temp");
     pTextureManager_->AddSearchPath("resources");
 


### PR DESCRIPTION
## SampleProgram::Initialize
* シーンファクトリの設定後にモデルマネージャーに自動ロードパスとして "resources/models" ディレクトリが追加されました。
  * `pModelManager_->AddAutoLoadPath("resources/models");` という行が追加されました。
  * これにより、指定されたディレクトリからモデルが自動的にロードされるようになります。