### PR TITLE
GameEyeとPG3PT1クラスの機能追加と修正

### DIFF
--- a/Engine/Features/GameEye/GameEye.cpp
+++ b/Engine/Features/GameEye/GameEye.cpp
@@ -18,6 +18,7 @@ GameEye::GameEye()
     , vpMatrix_(vMatrix_* pMatrix_)
 {
     DebugManager::GetInstance()->SetComponent("GameEye", name_, std::bind(&GameEye::DebugWindow, this));
+    pRandomGenerator_ = RandomGenerator::GetInstance();
 }
 
 GameEye::~GameEye()
@@ -27,10 +28,12 @@ GameEye::~GameEye()
 
 void GameEye::Update()
 {
-    wMatrix_ = Matrix4x4::AffineMatrix({ 1.0f, 1.0f, 1.0f }, transform_.rotate, transform_.translate);
+    wMatrix_ = Matrix4x4::AffineMatrix({ 1.0f, 1.0f, 1.0f }, transform_.rotate, transform_.translate + shakePositon_);
     vMatrix_ = wMatrix_.Inverse();
     pMatrix_ = Matrix4x4::PerspectiveFovMatrix(fovY_, aspectRatio_, nearClip_, farClip_);
     vpMatrix_ = vMatrix_ * pMatrix_;
+
+    shakePositon_ = Vector3();
 }
 
 void GameEye::DebugWindow()
@@ -53,4 +56,22 @@ void GameEye::DebugWindow()
     ImGui::PopID();
 
 #endif
+}
+
+void GameEye::Shake(const Vector3& _begin, const Vector3& _end)
+{
+    shakePositon_ = Vector3(
+        pRandomGenerator_->Generate(_begin.x, _end.x),
+        pRandomGenerator_->Generate(_begin.y, _end.y),
+        pRandomGenerator_->Generate(_begin.z, _end.z)
+    );
+}
+
+void GameEye::Shake(float _power)
+{
+    shakePositon_ = Vector3(
+        pRandomGenerator_->Generate(-_power, _power),
+        pRandomGenerator_->Generate(-_power, _power),
+        pRandomGenerator_->Generate(-_power, _power)
+    );
 }

--- a/Engine/Features/GameEye/GameEye.h
+++ b/Engine/Features/GameEye/GameEye.h
@@ -2,6 +2,7 @@
 #include <Common/structs.h>
 #include <Matrix4x4.h>
 #include <string>
+#include <Features/RandomGenerator/RandomGenerator.h>
 
 class GameEye
 {
@@ -9,6 +10,11 @@ public:
     GameEye();
     ~GameEye();
     void                Update();
+
+
+public:
+    void Shake(const Vector3& _begin, const Vector3& _end);
+    void Shake(float _power);
 
 public: /// Getter
     const Transform&    GetTransform() const            { return transform_; }
@@ -40,7 +46,12 @@ private: /// メンバ変数
     float               aspectRatio_    = 0.0f;
     float               nearClip_       = 0.0f;
     float               farClip_        = 0.0f;
+    Vector3             shakePositon_   = {};
 
 private:
     void DebugWindow();
+
+
+private:
+    RandomGenerator* pRandomGenerator_ = nullptr;
 };

--- a/SampleProject/Scene/PG3PT1/PG3PT1.cpp
+++ b/SampleProject/Scene/PG3PT1/PG3PT1.cpp
@@ -4,6 +4,8 @@
 
 void PG3PT1::Initialize()
 {
+    pInput_ = Input::GetInstance();
+
     pGameEye_ = std::make_unique<GameEye>();
     pBunny_ = std::make_unique<Object3d>();
 
@@ -30,6 +32,11 @@ void PG3PT1::Finalize()
 
 void PG3PT1::Update()
 {
+    if ( pInput_->PushKey(DIK_SPACE) )
+    {
+        pGameEye_->Shake(0.01f);
+    }
+
     pGameEye_->Update();
     pBunny_->Update();
 }

--- a/SampleProject/Scene/PG3PT1/PG3PT1.h
+++ b/SampleProject/Scene/PG3PT1/PG3PT1.h
@@ -3,6 +3,7 @@
 #include <Interfaces/IScene.h>
 #include <Features/Object3d/Object3d.h>
 #include <Features/GameEye/GameEye.h>
+#include <Features/Input/Input.h>
 #include <Common/structs.h>
 
 class PG3PT1 : public IScene
@@ -28,4 +29,8 @@ private:
     DirectionalLight directionalLight_ = {};
 
     bool isOpen_ = true;
+
+
+private:
+    Input* pInput_ = nullptr;
 };


### PR DESCRIPTION
## GameEyeクラス
- コンストラクタにおいて、`RandomGenerator`のインスタンスを取得するコードを追加
- `Update`メソッドで、`shakePositon_`を`transform_.translate`に加算するように変更し、`shakePositon_`をリセットするコードを追加
- 新しいメソッド`Shake`を追加し、指定された範囲またはパワーでランダムなシェイク位置を生成する機能を追加
- `GameEye.h`において、`RandomGenerator`のヘッダーをインクルードし、`Shake`メソッドの宣言を追加
- `shakePositon_`と`pRandomGenerator_`のメンバ変数を追加

## PG3PT1クラス
- `Initialize`メソッドにおいて、`Input`インスタンスを取得するコードを追加
- `Update`メソッドで、スペースキーが押されたときに`GameEye`の`Shake`メソッドを呼び出すコードを追加
- `PG3PT1.h`において、`Input`のヘッダーをインクルードし、`pInput_`のメンバ変数を追加