### PR TITLE
WinMainからNimaFrameworkのインスタンス作成を削除

### DIFF
--- a/Engine/Framework/NimaFramework.h
+++ b/Engine/Framework/NimaFramework.h
@@ -78,3 +78,16 @@ int _stdcall WinMain(HINSTANCE, HINSTANCE, LPSTR, int) \
     program->Run(); \
     return 0; \
 }
+
+#define CREATE_FRAMEWORK(classname) \
+\
+class classname : public NimaFramework \
+{ \
+public: \
+    void Initialize() override; \
+    void Finalize() override; \
+    void Update() override; \
+    void Draw() override; \
+    bool IsExitProgram() { return isExitProgram_; } \
+private: \
+};


### PR DESCRIPTION
# 変更内容
## WinMain
- `WinMain` 関数の中で `NimaFramework` のインスタンスを作成するコードが削除されました。

## マクロ
- `CREATE_FRAMEWORK` マクロが追加されました。

## NimaFramework
- `NimaFramework` を継承するクラスのテンプレートが追加されました。
  - `Initialize` メソッドがオーバーライドされました。
  - `Finalize` メソッドがオーバーライドされました。
  - `Update` メソッドがオーバーライドされました。
  - `Draw` メソッドがオーバーライドされました。
  - `IsExitProgram` メソッドが追加されました。