### PR TITLE
DirectX12とUIの改善およびリファクタリング

### DIFF
--- a/Engine/Core/DirectX12/DirectX12.cpp
+++ b/Engine/Core/DirectX12/DirectX12.cpp
@@ -225,11 +225,11 @@ void DirectX12::CopyFromRTV()
 
     /// コピー範囲
     D3D12_BOX srcBox = {};
-    srcBox.left = 0;
-    srcBox.top = 0;
+    srcBox.left = static_cast<UINT>(viewport_.TopLeftX);
+    srcBox.top = static_cast<UINT>(viewport_.TopLeftY);
+    srcBox.right = static_cast<UINT>(viewport_.Width + viewport_.TopLeftX);
+    srcBox.bottom = static_cast<UINT>(viewport_.Height + viewport_.TopLeftY);
     srcBox.front = 0;
-    srcBox.right = static_cast<UINT>(viewport_.Width);
-    srcBox.bottom = static_cast<UINT>(viewport_.Height);
     srcBox.back = 1;
 
     commandList_->CopyTextureRegion(&dstLocation, 0, 0, 0, &srcLocation, &srcBox);
@@ -245,7 +245,7 @@ void DirectX12::CopyFromRTV()
     );
 
     /// rtvのクリア
-    //commandList_->ClearRenderTargetView(rtvHandles_[backBufferIndex_], &editorBG_.x, 0, nullptr);
+    commandList_->ClearRenderTargetView(rtvHandles_[backBufferIndex_], &editorBG_.x, 0, nullptr);
 }
 
 void DirectX12::ChangeStateRTV(D3D12_RESOURCE_STATES _now, D3D12_RESOURCE_STATES _next)

--- a/Engine/Core/DirectX12/DirectX12_Impl.cpp
+++ b/Engine/Core/DirectX12/DirectX12_Impl.cpp
@@ -305,7 +305,7 @@ void DirectX12::CreateGameScreenResource()
         &heapPropertiesUAV,
         D3D12_HEAP_FLAG_NONE,
         &textureDesc,
-        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
         nullptr,
         IID_PPV_ARGS(&gameScreenComputed_)
     );

--- a/Engine/Core/DirectX12/SRVManager.cpp
+++ b/Engine/Core/DirectX12/SRVManager.cpp
@@ -110,6 +110,7 @@ void SRVManager::CreateForUAV(uint32_t _index, ID3D12Resource* _pTexture, DXGI_F
     D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
     uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
     uavDesc.Format = _format;
+    uavDesc.Texture2D.MipSlice = 0;
 
     pDx12_->GetDevice()->CreateUnorderedAccessView(_pTexture, nullptr, &uavDesc, GetCPUDescriptorHandle(_index));
 }

--- a/Engine/DebugTools/DebugManager/DebugManager.cpp
+++ b/Engine/DebugTools/DebugManager/DebugManager.cpp
@@ -203,8 +203,6 @@ void DebugManager::DrawUI()
 
     DebugInfoBar();
 
-    //DrawGameWindow();
-
     DebugInfoWindow();
 
     // 登録されていないなら早期リターン

--- a/Engine/EngineResources/Shaders/WithoutAlpha.CS.hlsl
+++ b/Engine/EngineResources/Shaders/WithoutAlpha.CS.hlsl
@@ -10,10 +10,7 @@ void CSMain(uint3 dtid : SV_DispatchThreadID)
 {
     // ピクセルカラーを取得
     float4 color = inputTexture.Load(int3(dtid.xy, 0));
-    
-    // グレースケール変換
-    float gray = dot(color.rgb, float3(0.299, 0.587, 0.114));
-    
+        
     // 出力テクスチャに書き込み
-    outputTexture[dtid.xy] = float4(gray, gray, gray, 1.0);
+    outputTexture[dtid.xy] = float4(color.xyz, 1.0);
 }

--- a/Engine/Features/Model/ModelManager.h
+++ b/Engine/Features/Model/ModelManager.h
@@ -3,9 +3,7 @@
 #include <unordered_map>
 #include <string>
 #include <memory>
-#include <Core/DirectX12/DirectX12.h>
 #include <list>
-#include <functional>
 #include <queue>
 #include "Model.h"
 #include <filesystem>

--- a/Engine/Features/Viewport/Viewport.h
+++ b/Engine/Features/Viewport/Viewport.h
@@ -16,6 +16,8 @@ public:
     void Initialize();
     void Compute();
 
+    void DrawWindow();
+
 
 public: /// Getter
     uint32_t GetOutputSRVIndex() const { return outputSRVIndex_; }

--- a/Engine/Framework/NimaFramework.cpp
+++ b/Engine/Framework/NimaFramework.cpp
@@ -1,4 +1,5 @@
 #include "NimaFramework.h"
+#include <clocale>
 
 void NimaFramework::Run()
 {
@@ -99,8 +100,8 @@ void NimaFramework::Initialize()
     pDirectX_->CreateGameScreenResource();
 
     /// ビューポートの初期化
-    //pViewport_ = std::make_unique<Viewport>();
-    //pViewport_->Initialize();
+    pViewport_ = std::make_unique<Viewport>();
+    pViewport_->Initialize();
 
     /// シーンマネージャの初期化
     pSceneManager_->Initialize();
@@ -132,6 +133,7 @@ void NimaFramework::Update()
     pImGuiManager_->BeginFrame();
     pDebugManager_->Update();
     pDebugManager_->DrawUI();
+    pViewport_->DrawWindow();
     pLogger_->DrawUI();
 
     /// シーン更新

--- a/Engine/Framework/NimaFramework.h
+++ b/Engine/Framework/NimaFramework.h
@@ -18,7 +18,6 @@
 #include <Features/Particle/ParticleManager.h>
 #include <Features/Line/LineSystem.h>
 #include <Features/RandomGenerator/RandomGenerator.h>
-#include <Features/Line/Line.h>
 #include <Features/Text/TextSystem.h>
 #include <Features/Viewport/Viewport.h>
 

--- a/SampleProject/EngineResources/Shaders/WithoutAlpha.CS.hlsl
+++ b/SampleProject/EngineResources/Shaders/WithoutAlpha.CS.hlsl
@@ -10,10 +10,7 @@ void CSMain(uint3 dtid : SV_DispatchThreadID)
 {
     // ピクセルカラーを取得
     float4 color = inputTexture.Load(int3(dtid.xy, 0));
-    
-    // グレースケール変換
-    float gray = dot(color.rgb, float3(0.299, 0.587, 0.114));
-    
+        
     // 出力テクスチャに書き込み
-    outputTexture[dtid.xy] = float4(gray, gray, gray, 1.0);
+    outputTexture[dtid.xy] = float4(color.xyz, 1.0);
 }

--- a/SampleProject/EngineResources/imgui.ini
+++ b/SampleProject/EngineResources/imgui.ini
@@ -4,20 +4,20 @@ Size=756,957
 Collapsed=0
 
 [Window][Log]
-Pos=0,25
-Size=15,27
+Pos=17,17
+Size=6,27
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Objects]
-Pos=0,17
-Size=7,27
+Pos=0,0
+Size=15,32
 Collapsed=0
 DockId=0x00000005,0
 
 [Window][デバッグ]
-Pos=17,17
-Size=15,27
+Pos=25,0
+Size=7,27
 Collapsed=0
 DockId=0x00000009,0
 
@@ -27,9 +27,9 @@ Size=373,177
 Collapsed=0
 
 [Window][GameWindow]
-Pos=448,403
-Size=18,27
+Size=15,27
 Collapsed=0
+DockId=0x00000006,0
 
 [Window][SceneManager]
 Pos=465,565
@@ -52,22 +52,16 @@ Size=97,64
 Collapsed=0
 
 [Window][DebugInfoBar]
-Pos=0,0
-Size=32,15
+Pos=17,0
+Size=6,7
 Collapsed=0
 DockId=0x00000007,0
 
 [Window][DebugInfo]
-Pos=17,30
-Size=15,27
+Pos=25,28
+Size=7,27
 Collapsed=0
 DockId=0x0000000A,0
-
-[Window][Viewport]
-Pos=9,17
-Size=6,27
-Collapsed=0
-DockId=0x00000006,0
 
 [Table][0x3DFC7327,2]
 Column 0  Weight=1.0000
@@ -481,28 +475,16 @@ Column 1  Weight=1.0000
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
-[Table][0x4CA3CC52,2]
-Column 0  Weight=1.0000
-Column 1  Weight=1.0000
-
-[Table][0xB77C405B,2]
-Column 0  Weight=1.0000
-Column 1  Weight=1.0000
-
-[Table][0x8C34076F,2]
-Column 0  Weight=1.0000
-Column 1  Weight=1.0000
-
 [Docking][Data]
-DockSpace         ID=0xD5ACB325 Window=0xA87D555D Pos=0,0 Size=32,32 Split=Y
-  DockNode        ID=0x00000007 Parent=0xD5ACB325 SizeRef=1600,37 HiddenTabBar=1 Selected=0x8EDA8100
-  DockNode        ID=0x00000008 Parent=0xD5ACB325 SizeRef=1600,861 Split=X
-    DockNode      ID=0x00000003 Parent=0x00000008 SizeRef=1249,900 Split=Y
-      DockNode    ID=0x00000001 Parent=0x00000003 SizeRef=1600,653 Split=X Selected=0xBA965914
-        DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=127,670 Selected=0x967E7699
-        DockNode  ID=0x00000006 Parent=0x00000001 SizeRef=1120,670 CentralNode=1 Selected=0x13926F0B
-      DockNode    ID=0x00000002 Parent=0x00000003 SizeRef=1600,206 Selected=0x64F50EE5
-    DockNode      ID=0x00000004 Parent=0x00000008 SizeRef=349,900 Split=Y Selected=0x435A4E3F
+DockSpace         ID=0xD5ACB325 Window=0xA87D555D Pos=0,0 Size=32,32 Split=X
+  DockNode        ID=0x00000005 Parent=0xD5ACB325 SizeRef=128,900 Selected=0x967E7699
+  DockNode        ID=0x00000006 Parent=0xD5ACB325 SizeRef=1470,900 Split=X
+    DockNode      ID=0x00000003 Parent=0x00000006 SizeRef=1120,900 Split=Y
+      DockNode    ID=0x00000001 Parent=0x00000003 SizeRef=1600,670 Split=Y Selected=0x967E7699
+        DockNode  ID=0x00000007 Parent=0x00000001 SizeRef=1118,38 HiddenTabBar=1 Selected=0x8EDA8100
+        DockNode  ID=0x00000008 Parent=0x00000001 SizeRef=1118,630 CentralNode=1
+      DockNode    ID=0x00000002 Parent=0x00000003 SizeRef=1600,228 Selected=0x64F50EE5
+    DockNode      ID=0x00000004 Parent=0x00000006 SizeRef=348,900 Split=Y Selected=0x435A4E3F
       DockNode    ID=0x00000009 Parent=0x00000004 SizeRef=348,770 Selected=0x435A4E3F
       DockNode    ID=0x0000000A Parent=0x00000004 SizeRef=348,128 Selected=0x627D110E
 

--- a/SampleProject/SampleProgram/SampleProgram.cpp
+++ b/SampleProject/SampleProgram/SampleProgram.cpp
@@ -77,8 +77,8 @@ void SampleProgram::Draw()
     pSpriteSystem_->PresentDraw();
     pSceneManager_->SceneDraw2dForeground();
 
-    //pDirectX_->CopyFromRTV();
-    //pViewport_->Compute();
+    pDirectX_->CopyFromRTV();
+    pViewport_->Compute();
 
     pImGuiManager_->EndFrame();
 


### PR DESCRIPTION
## DirectX12.cpp
- `DirectX12::CopyFromRTV` メソッドで `viewport_` プロパティを使用するように変更
- `ClearRenderTargetView` の呼び出しを有効化

## DirectX12_Impl.cpp
- `DirectX12::CreateGameScreenResource` メソッドでリソースの初期状態を `D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE` に変更

## SRVManager.cpp
- `SRVManager::CreateForUAV` メソッドで `uavDesc.Texture2D.MipSlice` を 0 に設定

## DebugManager.cpp
- `DebugManager::DrawUI` メソッドで `DrawGameWindow` のコメントアウトを削除

## WithoutAlpha.CS.hlsl
- グレースケール変換コードを削除し、元のカラー値を出力するように変更

## ModelManager.h
- `Core/DirectX12/DirectX12.h` と `functional` のインクルードを削除

## Viewport.cpp
- `dxcapi.h` のインクルードを削除し、`imgui.h` を追加
- `Viewport::CreateSRV` メソッドでテクスチャフォーマットを `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` に変更
- `Viewport::CreateUAV` メソッドでUAVのインデックス設定を修正
- `Viewport::Compute` メソッドでリソースステート変更コードを有効化
- `Viewport::DrawWindow` メソッドを追加

## Viewport.h
- `Viewport::DrawWindow` メソッドの宣言を追加

## NimaFramework.cpp
- `#include <clocale>` を追加
- `NimaFramework::Run` メソッドでロケール設定を追加
- `NimaFramework::Initialize` メソッドで `Viewport` の初期化コードを有効化
- `NimaFramework::Update` メソッドで `pViewport_->DrawWindow` の呼び出しを追加

## NimaFramework.h
- `Features/Line/Line.h` のインクルードを削除

## SampleProgram.cpp
- `SampleProgram::Draw` メソッドで `CopyFromRTV` と `Compute` の呼び出しを有効化

## imgui.ini
- ウィンドウ位置とサイズの設定を変更
- 新たに `Viewport` ウィンドウの設定を追加
- 新しいウィンドウとテーブル設定を追加
- ドッキングデータを追加