### PR TITLE
ウィンドウサイズ取得方法の変更と関連メソッドの更新

### DIFF
--- a/Engine/Core/DirectX12/DirectX12.cpp
+++ b/Engine/Core/DirectX12/DirectX12.cpp
@@ -50,8 +50,8 @@ void DirectX12::Initialize()
     hwnd_ = WinSystem::GetInstance()->GetHwnd();
 
     // ウィンドウのクライアントサイズを取得
-    clientWidth_ = WinSystem::kClientWidth;
-    clientHeight_ = WinSystem::kClientHeight;
+    clientWidth_ = WinSystem::clientWidth;
+    clientHeight_ = WinSystem::clientHeight;
 
     hr_ = CreateDXGIFactory(IID_PPV_ARGS(&dxgiFactory_));
 

--- a/Engine/Core/Win32/WinSystem.h
+++ b/Engine/Core/Win32/WinSystem.h
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <stdint.h>
 #include <Windows.h>
+#include <cstdint>
 
 class WinSystem
 {
 public:
-    static const uint32_t kClientWidth = 1600u;
-    static const uint32_t kClientHeight = 900u;
+    static uint32_t clientWidth;
+    static uint32_t clientHeight;
+    static uint32_t preClientWidth;
+    static uint32_t preClientHeight;
 
     WinSystem(const WinSystem&) = delete;
     WinSystem(const WinSystem&&) = delete;
@@ -35,7 +37,7 @@ private:
     WNDCLASS    wc_         = {};
     HWND        hwnd_       = {};
     MSG         msg_        = {};
-    POINT       wndSize_    = {};
+    RECT        wndSize_    = {};
     static bool isMoving_;
     static bool isResized_;
 };

--- a/Engine/DebugTools/ImGuiManager/ImGuiManager.cpp
+++ b/Engine/DebugTools/ImGuiManager/ImGuiManager.cpp
@@ -49,6 +49,25 @@ void ImGuiManager::Finalize()
 #endif // _DEBUG
 }
 
+void ImGuiManager::Resize()
+{
+    auto& io = ImGui::GetIO();
+    io.DisplaySize.x = static_cast<float>(WinSystem::clientWidth);
+    io.DisplaySize.y = static_cast<float>(WinSystem::clientHeight);
+
+    float scaleX = WinSystem::clientWidth / WinSystem::preClientWidth;
+    float scaleY = WinSystem::clientHeight / WinSystem::preClientHeight;
+
+    io.DisplayFramebufferScale = ImVec2(scaleX, scaleY);
+    
+    auto* drawData = ImGui::GetDrawData();
+    if(drawData)
+    {
+        drawData->DisplayPos = ImVec2(0.0f, 0.0f);
+        drawData->DisplaySize = ImVec2(io.DisplaySize.x, io.DisplaySize.y);
+    }
+}
+
 void ImGuiManager::BeginFrame()
 {
 #ifdef _DEBUG

--- a/Engine/DebugTools/ImGuiManager/ImGuiManager.h
+++ b/Engine/DebugTools/ImGuiManager/ImGuiManager.h
@@ -17,6 +17,7 @@ public:
     void Render();
     void EndFrame();
     void Finalize();
+    void Resize();
 
 private:
     bool isChangedFont_ = false;

--- a/Engine/Features/GameEye/GameEye.cpp
+++ b/Engine/Features/GameEye/GameEye.cpp
@@ -9,7 +9,7 @@
 GameEye::GameEye()
     : transform_({ Vector3(1.0f, 1.0f, 1.0f), Vector3(0.0f, 0.0f, 0.0f), Vector3(0.0f, 0.0f, 0.0f) })
     , fovY_(0.45f)
-    , aspectRatio_(static_cast<float>(WinSystem::kClientWidth) / static_cast<float>(WinSystem::kClientHeight))
+    , aspectRatio_(static_cast<float>(WinSystem::clientWidth) / static_cast<float>(WinSystem::clientHeight))
     , nearClip_(0.1f)
     , farClip_(1000.0f)
     , wMatrix_(Matrix4x4::AffineMatrix(transform_.scale, transform_.rotate, transform_.translate))

--- a/Engine/Features/SceneTransition/TransFadeInOut.cpp
+++ b/Engine/Features/SceneTransition/TransFadeInOut.cpp
@@ -10,8 +10,8 @@ void TransFadeInOut::Initialize(const std::string& _sceneName)
 {
     sceneName_ = _sceneName;
 
-    screenWidth_ = WinSystem::kClientWidth;
-    screenHeight_ = WinSystem::kClientHeight;
+    screenWidth_ = WinSystem::clientWidth;
+    screenHeight_ = WinSystem::clientHeight;
 
     timer_ = std::make_unique<Timer>();
 

--- a/Engine/Framework/NimaFramework.cpp
+++ b/Engine/Framework/NimaFramework.cpp
@@ -126,6 +126,11 @@ void NimaFramework::Update()
         return;
     }
 
+    if(pWinSystem_->IsResized())
+    {
+        pImGuiManager_->Resize();
+    }
+
     /// マネージャ更新
     pInput_->Update();
     pModelManager_->Update();

--- a/Engine/Framework/NimaFramework.h
+++ b/Engine/Framework/NimaFramework.h
@@ -23,7 +23,7 @@
 
 #include <memory>
 
-// ゲーム共有
+/// ゲーム共通のフレームワーククラス
 class NimaFramework
 {
 public:

--- a/SampleProject/Scene/GameScene/GameScene.cpp
+++ b/SampleProject/Scene/GameScene/GameScene.cpp
@@ -1,12 +1,11 @@
 #include "GameScene.h"
 
-#include <Features/Model/ModelManager.h>
-#include <Features/Sprite/SpriteSystem.h>
 #include <Features/Object3d/Object3dSystem.h>
 #include <Features/Particle/ParticleSystem.h>
 #include <Features/SceneManager/SceneManager.h>
 #include <Features/Line/LineSystem.h>
 #include <Core/Win32/WinSystem.h>
+#include <Features/GameEye/FreeLook/FreeLookEye.h>
 
 
 void GameScene::Initialize()
@@ -18,14 +17,14 @@ void GameScene::Initialize()
     pSpark_ = std::make_unique<ParticleEmitter>();
 
 
-    pGameEye_ = std::make_unique<GameEye>();
+    pGameEye_ = std::make_unique<FreeLookEye>();
     pSkydome_ = std::make_unique<Object3d>();
     pGrid_ = std::make_unique<Object3d>();
 
     pGuideSprite_ = std::make_unique<Sprite>();
     pGuideSprite_->Initialize("Text/SceneChangeGuide.png");
     pGuideSprite_->SetName("GuideText");
-    pGuideSprite_->SetPosition(Vector2(WinSystem::kClientWidth - 40.0f, WinSystem::kClientHeight - 40.0f));
+    pGuideSprite_->SetPosition(Vector2(WinSystem::clientWidth - 40.0f, WinSystem::clientHeight - 40.0f));
     pGuideSprite_->SetAnchorPoint({ 1,1 });
 
     pGameEye_->SetRotate({ 0.1f, 0.0f, 0.0f });

--- a/SampleProject/imgui.ini
+++ b/SampleProject/imgui.ini
@@ -493,6 +493,10 @@ Column 1  Weight=1.0000
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
+[Table][0x0ABE1544,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
 [Docking][Data]
 DockSpace         ID=0xD5ACB325 Window=0xA87D555D Pos=0,0 Size=32,32 Split=Y
   DockNode        ID=0x00000007 Parent=0xD5ACB325 SizeRef=1600,37 HiddenTabBar=1 Selected=0x8EDA8100


### PR DESCRIPTION
## DirectX12
- `DirectX12::Initialize` メソッドで、ウィンドウのクライアントサイズの取得方法が `WinSystem::kClientWidth` と `WinSystem::kClientHeight` から `WinSystem::clientWidth` と `WinSystem::clientHeight` に変更されました。

## WinSystem
- `WinSystem.cpp` に `clientWidth` と `clientHeight` の初期値を設定するコードが追加されました（それぞれ1600と900）。
- `WinSystem::Finalize` メソッドで、ウィンドウのクライアントサイズを取得する際のコードが更新されました。
- `WinSystem::ShowWnd` メソッドで、ウィンドウのクライアントサイズを取得する際のコードが更新されました。
- `WinSystem::IsResized` メソッドで、ウィンドウのサイズ変更時にクライアントサイズを更新するコードが追加されました。
- `WinSystem::WindowProcedure` メソッドで、ウィンドウサイズ変更開始と終了のメッセージ処理が追加されました。
- `WinSystem.h` で、クライアントサイズに関する定数が削除され、代わりに静的メンバー変数 `clientWidth` と `clientHeight` が追加されました。

## ImGuiManager
- `ImGuiManager.cpp` に `Resize` メソッドが追加され、ImGuiの表示サイズとフレームバッファのスケールを更新する処理が追加されました。
- `ImGuiManager.h` に `Resize` メソッドの宣言が追加されました。

## GameEye
- `GameEye.cpp` で、アスペクト比の計算に使用するクライアントサイズが `WinSystem::kClientWidth` と `WinSystem::kClientHeight` から `WinSystem::clientWidth` と `WinSystem::clientHeight` に変更されました。

## TransFadeInOut
- `TransFadeInOut.cpp` で、画面サイズの取得方法が `WinSystem::kClientWidth` と `WinSystem::kClientHeight` から `WinSystem::clientWidth` と `WinSystem::clientHeight` に変更されました。

## NimaFramework
- `NimaFramework.cpp` の `Update` メソッドで、ウィンドウサイズが変更された場合に `ImGuiManager::Resize` メソッドを呼び出す処理が追加されました。

## GameScene
- `GameScene.cpp` で、カメラの初期化に使用するクラスが `GameEye` から `FreeLookEye` に変更されました。
- ガイドスプライトの位置設定に使用するクライアントサイズが `WinSystem::kClientWidth` と `WinSystem::kClientHeight` から `WinSystem::clientWidth` と `WinSystem::clientHeight` に変更されました。

## その他
- `imgui.ini` に新しいテーブル設定が追加されました。