### PR TITLE
WinSystemとImGuiManagerのスケーリング修正

### DIFF
--- a/Engine/Core/Win32/WinSystem.cpp
+++ b/Engine/Core/Win32/WinSystem.cpp
@@ -9,6 +9,8 @@ extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg
 
 uint32_t WinSystem::clientWidth = 1600;
 uint32_t WinSystem::clientHeight = 900;
+uint32_t WinSystem::preClientWidth = 1600;
+uint32_t WinSystem::preClientHeight = 900;
 
 bool WinSystem::isMoving_ = false;
 bool WinSystem::isResized_ = false;

--- a/Engine/DebugTools/ImGuiManager/ImGuiManager.cpp
+++ b/Engine/DebugTools/ImGuiManager/ImGuiManager.cpp
@@ -55,8 +55,8 @@ void ImGuiManager::Resize()
     io.DisplaySize.x = static_cast<float>(WinSystem::clientWidth);
     io.DisplaySize.y = static_cast<float>(WinSystem::clientHeight);
 
-    float scaleX = WinSystem::clientWidth / WinSystem::preClientWidth;
-    float scaleY = WinSystem::clientHeight / WinSystem::preClientHeight;
+    float scaleX = static_cast<float>(WinSystem::clientWidth) / static_cast<float>(WinSystem::preClientWidth);
+    float scaleY = static_cast<float>(WinSystem::clientHeight) / static_cast<float>(WinSystem::preClientHeight);
 
     io.DisplayFramebufferScale = ImVec2(scaleX, scaleY);
     


### PR DESCRIPTION
## WinSystem.cpp
- 新しいメンバー変数 `preClientWidth` と `preClientHeight` を追加
  - 初期値は `clientWidth` と `clientHeight` と同じ 1600 と 900

## ImGuiManager.cpp
- `Resize` 関数でスケーリングの計算を整数除算から浮動小数点除算に変更
  - より正確なスケーリングが可能に