### PR TITLE
RTVとSRVのフォーマット変更およびログメッセージ追加

### DIFF
--- a/Engine/Core/DirectX12/DirectX12_Impl.cpp
+++ b/Engine/Core/DirectX12/DirectX12_Impl.cpp
@@ -238,7 +238,7 @@ void DirectX12::CreateSwapChainAndResource()
 
 
     /// RTVの設定
-    rtvDesc_.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    rtvDesc_.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
     rtvDesc_.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
 
 
@@ -260,7 +260,7 @@ void DirectX12::CreateGameScreenResource()
     resourceDesc.Height = static_cast<UINT>(viewport_.Height);              // 高さ
     resourceDesc.MipLevels = 1;                                             // mipmapの数
     resourceDesc.DepthOrArraySize = 1;                                      // 奥行き or 配列Textureの配列数
-    resourceDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;                  // フォーマット
+    resourceDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;                       // フォーマット
     resourceDesc.SampleDesc.Count = 1;                                      // サンプリング数
     resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;            // 2DTexture
     resourceDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;        // UAVを使うためのフラグ
@@ -282,7 +282,7 @@ void DirectX12::CreateGameScreenResource()
     /// SRVの生成
     SRVManager* psrvm = SRVManager::GetInstance();
     gameWndSrvIndex_ = psrvm->Allocate();
-    psrvm->CreateForTexture2D(gameWndSrvIndex_, gameScreenResource_.Get(), DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, 1);
+    psrvm->CreateForTexture2D(gameWndSrvIndex_, gameScreenResource_.Get(), DXGI_FORMAT_R8G8B8A8_UNORM, 1);
 
     /// UAVの生成
     D3D12_RESOURCE_DESC textureDesc = {};

--- a/Engine/DebugTools/ImGuiManager/ImGuiManager.cpp
+++ b/Engine/DebugTools/ImGuiManager/ImGuiManager.cpp
@@ -30,7 +30,7 @@ void ImGuiManager::Initialize(DirectX12* _pDx12)
     ImGui_ImplDX12_Init(
         device,
         swapChainDesc.BufferCount,
-        DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
+        DXGI_FORMAT_R8G8B8A8_UNORM,
         srvDescHeap_,
         srvDescHeap_->GetCPUDescriptorHandleForHeapStart(),
         srvDescHeap_->GetGPUDescriptorHandleForHeapStart()

--- a/Engine/Features/Line/LineSystem.cpp
+++ b/Engine/Features/Line/LineSystem.cpp
@@ -117,7 +117,7 @@ void LineSystem::CreatePipelineState()
     pipelineStateDesc.RasterizerState = rasterizerDesc; // RasterizerState
     // 書き込むRTVの情報
     pipelineStateDesc.NumRenderTargets = 1;
-    pipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    pipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
     // 利用するトポロジ（形状）のタイプ。ライン
     pipelineStateDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE;
     // どのように画面に色を打ち込むかの設定

--- a/Engine/Features/Model/Model.cpp
+++ b/Engine/Features/Model/Model.cpp
@@ -25,7 +25,7 @@ void Model::Initialize(const std::string& _filePath)
         Logger::GetInstance()->LogInfo(
             "Model",
             "LoadModel",
-            "Succeed"
+            "Succeed : " + directoryPath_ + filePath_
         );
     });
 }

--- a/Engine/Features/Object3d/Object3dSystem.cpp
+++ b/Engine/Features/Object3d/Object3dSystem.cpp
@@ -219,7 +219,7 @@ void Object3dSystem::CreateMainPipelineState()
     graphicsPipelineStateDesc.RasterizerState = rasterizerDesc_;    // RasterizerState
     // 書き込むRTVの情報
     graphicsPipelineStateDesc.NumRenderTargets = 1;
-    graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
     // 利用するトポロジ（形状）のタイプ。三角形
     graphicsPipelineStateDesc.PrimitiveTopologyType =
         D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;

--- a/Engine/Features/Particle/ParticleSystem.cpp
+++ b/Engine/Features/Particle/ParticleSystem.cpp
@@ -192,7 +192,7 @@ void ParticleSystem::CreatePipelineState()
     graphicsPipelineStateDesc.RasterizerState = rasterizerDesc;    // RasterizerState
     // 書き込むRTVの情報
     graphicsPipelineStateDesc.NumRenderTargets = 1;
-    graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
     // 利用するトポロジ（形状）のタイプ。三角形
     graphicsPipelineStateDesc.PrimitiveTopologyType =
         D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;

--- a/Engine/Features/Sprite/SpriteSystem.cpp
+++ b/Engine/Features/Sprite/SpriteSystem.cpp
@@ -193,7 +193,7 @@ void SpriteSystem::CreatePipelineState()
     graphicsPipelineStateDesc.RasterizerState = rasterizerDesc;	// RasterizerState
     // 書き込むRTVの情報
     graphicsPipelineStateDesc.NumRenderTargets = 1;
-    graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
     // 利用するトポロジ（形状）のタイプ。三角形
     graphicsPipelineStateDesc.PrimitiveTopologyType =
         D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;

--- a/Engine/Features/Viewport/Viewport.cpp
+++ b/Engine/Features/Viewport/Viewport.cpp
@@ -133,7 +133,7 @@ void Viewport::CreateSRV()
     pSRVManager_->CreateForTexture2D(inputSRVIndex_, inputTexture_, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, 1);
 
     outputSRVIndex_ = pSRVManager_->Allocate();
-    pSRVManager_->CreateForTexture2D(outputSRVIndex_, outputTexture_, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, 1);
+    pSRVManager_->CreateForTexture2D(outputSRVIndex_, outputTexture_, DXGI_FORMAT_R8G8B8A8_UNORM, 1);
 }
 
 void Viewport::CreateUAV()

--- a/SampleProject/Scene/PG3PT1/PG3PT1.cpp
+++ b/SampleProject/Scene/PG3PT1/PG3PT1.cpp
@@ -11,7 +11,7 @@ void PG3PT1::Initialize()
 
     directionalLight_.color = { 1.0f, 1.0f, 1.0f, 1.0f };
     directionalLight_.direction = { 0.0f, -1.0f, 0.0f };
-    directionalLight_.intensity = 0.1f;
+    directionalLight_.intensity = 1.0f;
 
     pGameEye_->SetTranslate({ 0.0f, 0.0f, -5.0f });
     pGameEye_->SetRotate({ 0.0f, 0.0f, 0.0f });

--- a/SampleProject/imgui.ini
+++ b/SampleProject/imgui.ini
@@ -32,7 +32,7 @@ Size=18,27
 Collapsed=0
 
 [Window][SceneManager]
-Pos=465,565
+Pos=441,604
 Size=522,63
 Collapsed=0
 


### PR DESCRIPTION
## DirectX12
- `CreateSwapChainAndResource` 関数内で、RTVのフォーマットが `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` から `DXGI_FORMAT_R8G8B8A8_UNORM` に変更されました。
- `CreateGameScreenResource` 関数内で、リソースのフォーマットが `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` から `DXGI_FORMAT_R8G8B8A8_UNORM` に変更されました。
- `CreateGameScreenResource` 関数内で、SRVの生成時のフォーマットが `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` から `DXGI_FORMAT_R8G8B8A8_UNORM` に変更されました。

## ImGuiManager
- `Initialize` 関数内で、ImGuiの初期化時のフォーマットが `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` から `DXGI_FORMAT_R8G8B8A8_UNORM` に変更されました。

## LineSystem
- `CreatePipelineState` 関数内で、RTVのフォーマットが `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` から `DXGI_FORMAT_R8G8B8A8_UNORM` に変更されました。

## Model
- `Initialize` 関数内で、ログメッセージにモデルのディレクトリパスとファイルパスが追加されました。

## Object3dSystem
- `CreateMainPipelineState` 関数内で、RTVのフォーマットが `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` から `DXGI_FORMAT_R8G8B8A8_UNORM` に変更されました。

## ParticleSystem
- `CreatePipelineState` 関数内で、RTVのフォーマットが `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` から `DXGI_FORMAT_R8G8B8A8_UNORM` に変更されました。

## SpriteSystem
- `CreatePipelineState` 関数内で、RTVのフォーマットが `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` から `DXGI_FORMAT_R8G8B8A8_UNORM` に変更されました。

## Viewport
- `CreateSRV` 関数内で、SRVの生成時のフォーマットが `DXGI_FORMAT_R8G8B8A8_UNORM_SRGB` から `DXGI_FORMAT_R8G8B8A8_UNORM` に変更されました。

## PG3PT1
- `Initialize` 関数内で、ディレクショナルライトの強度が `0.1f` から `1.0f` に変更されました。

## imgui.ini
- `SceneManager` ウィンドウの位置が変更されました。