### PR TITLE
NiUIへのリファクタリング

### DIFF
--- a/Engine/Core/Win32/WinSystem.cpp
+++ b/Engine/Core/Win32/WinSystem.cpp
@@ -1,7 +1,7 @@
 #include "WinSystem.h"
 #include <cassert>
 
-#include <Features/UI/UI.h>
+#include <Features/NiUI/NiUI.h>
 
 #ifdef _DEBUG
 #include <imgui.h>
@@ -87,7 +87,7 @@ bool WinSystem::IsResized()
 
 LRESULT CALLBACK WinSystem::WindowProcedure(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
-    UI::NiUI_WndProcHandler(hwnd, msg, wparam, lparam);
+    NiUI::NiUI_WndProcHandler(hwnd, msg, wparam, lparam);
 
     #ifdef _DEBUG
     if(ImGui_ImplWin32_WndProcHandler(hwnd, msg, wparam, lparam))

--- a/Engine/Features/NiUI/Derived/Drawer.h
+++ b/Engine/Features/NiUI/Derived/Drawer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Features/UI/Interface/IDrawer.h>
+#include <Features/NiUI/Interface/NiUI_IDrawer.h>
 
 #include <Features/Sprite/Sprite.h>
 #include <list>

--- a/Engine/Features/NiUI/Interface/NiUI_IDrawer.cpp
+++ b/Engine/Features/NiUI/Interface/NiUI_IDrawer.cpp
@@ -1,4 +1,4 @@
-#include "IDrawer.h"
+#include "NiUI_IDrawer.h"
 
 void IDrawer::DrawSetting()
 {

--- a/Engine/Features/NiUI/Interface/NiUI_IDrawer.h
+++ b/Engine/Features/NiUI/Interface/NiUI_IDrawer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Type/ComponentData.h"
+#include "../Type/NiUI_ComponentData.h"
 #include <list>
 
 class IDrawer

--- a/Engine/Features/NiUI/NiUI.cpp
+++ b/Engine/Features/NiUI/NiUI.cpp
@@ -1,18 +1,18 @@
-#include "UI.h"
+#include "NiUI.h"
 
 #include <stdexcept> // runtime_error
 
-UI_Input UI::input_ = UI_Input();
-bool UI::isInitialized_ = false;
-bool UI::isBeginFrame_ = false;
-NiVec2 UI::leftTop_ = { 0, 0 };
-NiVec2 UI::size_ = { 0, 0 };
-std::unordered_map<std::string, ButtonImageData> UI::buttonImages_ = std::unordered_map<std::string, ButtonImageData>();
-std::string UI::activeComponentID_ = {};
-IDrawer* UI::drawer_ = nullptr;
+NiUI_Input NiUI::input_ = NiUI_Input();
+bool NiUI::isInitialized_ = false;
+bool NiUI::isBeginFrame_ = false;
+NiVec2 NiUI::leftTop_ = { 0, 0 };
+NiVec2 NiUI::size_ = { 0, 0 };
+std::unordered_map<std::string, ButtonImageData> NiUI::buttonImages_ = std::unordered_map<std::string, ButtonImageData>();
+std::string NiUI::activeComponentID_ = {};
+IDrawer* NiUI::drawer_ = nullptr;
 
 
-void UI::Initialize(const NiVec2& _size, const NiVec2& _leftTop)
+void NiUI::Initialize(const NiVec2& _size, const NiVec2& _leftTop)
 {
     isInitialized_ = true;
     leftTop_ = _leftTop;
@@ -24,7 +24,7 @@ void UI::Initialize(const NiVec2& _size, const NiVec2& _leftTop)
 }
 
 
-void UI::BeginFrame()
+void NiUI::BeginFrame()
 {
     CheckValid_BeginFrame();
 
@@ -37,7 +37,7 @@ void UI::BeginFrame()
     return;
 }
 
-void UI::DrawUI()
+void NiUI::DrawUI()
 {
     // 描画処理に必要なデータの確認
     CheckValid_DrawUI();
@@ -55,13 +55,13 @@ void UI::DrawUI()
     isBeginFrame_ = false;
 }
 
-void UI::NiUI_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+void NiUI::NiUI_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     input_.WndProcHandler(hWnd, msg, wParam, lParam);
     return;
 }
 
-bool UI::Button(const std::string& _id, const std::string& _textureName, const NiVec2& _leftTop, const NiVec2& _size)
+bool NiUI::Button(const std::string& _id, const std::string& _textureName, const NiVec2& _leftTop, const NiVec2& _size)
 {
     auto& buttonImage = buttonImages_[_id];
     bool isTrigger = false;
@@ -85,7 +85,7 @@ bool UI::Button(const std::string& _id, const std::string& _textureName, const N
     return result;
 }
 
-bool UI::ButtonBehavior(const std::string& _id, bool _isHover, bool _isTrigger, bool _isRelease, bool& _out_held)
+bool NiUI::ButtonBehavior(const std::string& _id, bool _isHover, bool _isTrigger, bool _isRelease, bool& _out_held)
 {
     if(_isTrigger)
     {
@@ -106,7 +106,7 @@ bool UI::ButtonBehavior(const std::string& _id, bool _isHover, bool _isTrigger, 
     return false;
 }
 
-void UI::ButtonDataEnqueue()
+void NiUI::ButtonDataEnqueue()
 {
     for(auto& buttonImage : buttonImages_)
     {
@@ -115,7 +115,7 @@ void UI::ButtonDataEnqueue()
     }
 }
 
-void UI::CheckValid_BeginFrame()
+void NiUI::CheckValid_BeginFrame()
 {
     if(!isInitialized_)
     {
@@ -128,7 +128,7 @@ void UI::CheckValid_BeginFrame()
     }
 }
 
-void UI::CheckValid_DrawUI()
+void NiUI::CheckValid_DrawUI()
 {
     if(!isInitialized_)
     {
@@ -146,7 +146,7 @@ void UI::CheckValid_DrawUI()
     }
 }
 
-void UI::JudgeClickRect(const NiVec2& _leftTop, const NiVec2& _size, bool& _isHover, bool& _isTrigger, bool& _isRelease)
+void NiUI::JudgeClickRect(const NiVec2& _leftTop, const NiVec2& _size, bool& _isHover, bool& _isTrigger, bool& _isRelease)
 {
     NiVec2 leftTop = _leftTop + leftTop_;
 

--- a/Engine/Features/NiUI/NiUI.h
+++ b/Engine/Features/NiUI/NiUI.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Type/ComponentData.h" // ComponentData
+#include "Type/NiUI_ComponentData.h" // ComponentData
 #include "math/NiVec2.h" // NiVec2
-#include "UI_Input.h" // UI_Input
-#include "Interface/IDrawer.h"
+#include "NiUI_Input.h" // NiUI_Input
+#include "Interface/NiUI_IDrawer.h"
 
 #include <unordered_map> // unordered_map
 #include <string> // string
@@ -12,11 +12,11 @@
 
 
 /// UIクラス
-class UI
+class NiUI
 {
 public: /// コンストラクタとデストラクタ
-    UI() = default;
-    ~UI() = default;
+    NiUI() = default;
+    ~NiUI() = default;
 
 
 public: /// 一般
@@ -59,7 +59,7 @@ private: /// メンバ変数
     static bool isBeginFrame_;
 
     // 入力データ
-    static UI_Input input_;
+    static NiUI_Input input_;
 
     // ウィンドウのサイズ
     static NiVec2 leftTop_;

--- a/Engine/Features/NiUI/NiUI_Input.cpp
+++ b/Engine/Features/NiUI/NiUI_Input.cpp
@@ -1,13 +1,13 @@
-#include "UI_Input.h"
+#include "NiUI_Input.h"
 
 #include <WinUser.h> // WM_LBUTTONDOWN, WM_LBUTTONUP, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP
 
-void UI_Input::Initialize()
+void NiUI_Input::Initialize()
 {
     mouseData_ = {};
 }
 
-void UI_Input::Update()
+void NiUI_Input::Update()
 {
     /// 前フレームの状態を保存
     mouseData_.isLeftPre = mouseData_.isLeft;
@@ -32,7 +32,7 @@ void UI_Input::Update()
     mouseData_.pos = NiVec2(static_cast<float>(point.x), static_cast<float>(point.y));
 }
 
-void UI_Input::WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+void NiUI_Input::WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     hWnd_ = hWnd;
 

--- a/Engine/Features/NiUI/NiUI_Input.h
+++ b/Engine/Features/NiUI/NiUI_Input.h
@@ -5,25 +5,26 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h> // HWND, UINT, WPARAM, LPARAM
 
-/// マウスデータ
-struct MouseData
-{
-    NiVec2 pos;
-    bool isLeft;
-    bool isLeftPre;
-    bool isRight;
-    bool isRightPre;
-    bool isMiddle;
-    bool isMiddlePre;
-};
-
 
 /// UI入力クラス
-class UI_Input
+class NiUI_Input
 {
+public:
+    /// マウスデータ
+    struct MouseData
+    {
+        NiVec2 pos;
+        bool isLeft;
+        bool isLeftPre;
+        bool isRight;
+        bool isRightPre;
+        bool isMiddle;
+        bool isMiddlePre;
+    };
+
 public: /// コンストラクタとデストラクタ
-    UI_Input() = default;
-    ~UI_Input() = default;
+    NiUI_Input() = default;
+    ~NiUI_Input() = default;
 
 
 public: /// 一般

--- a/Engine/Features/NiUI/Type/NiUI_ComponentData.h
+++ b/Engine/Features/NiUI/Type/NiUI_ComponentData.h
@@ -7,7 +7,7 @@
 
 #include <string> // string
 #include "../math/NiVec2.h" // NiVec2
-#include "UIEnum.h" // enums
+#include "NiUI_Enum.h" // enums
 
 
 // フレックスコンテナのデータ

--- a/Engine/Framework/NimaFramework.cpp
+++ b/Engine/Framework/NimaFramework.cpp
@@ -1,7 +1,7 @@
 #include "NimaFramework.h"
 #include <clocale>
 
-#include <Features/UI/UI.h>
+#include <Features/NiUI/NiUI.h>
 
 void NimaFramework::Run()
 {
@@ -119,11 +119,11 @@ void NimaFramework::Initialize()
 
     /// UIの初期化
     auto vp = pDirectX_->GetViewport();
-    UI::Initialize({ vp.Width, vp.Height }, { vp.TopLeftX, vp.TopLeftY });
+    NiUI::Initialize({ vp.Width, vp.Height }, { vp.TopLeftX, vp.TopLeftY });
 
     /// Drawerの設定
     pDrawer_ = std::make_unique<Drawer>();
-    UI::SetDrawer(pDrawer_.get());
+    NiUI::SetDrawer(pDrawer_.get());
 }
 
 void NimaFramework::Finalize()
@@ -160,7 +160,7 @@ void NimaFramework::Update()
 
     #endif // _DEBUG
 
-    UI::BeginFrame();
+    NiUI::BeginFrame();
 
     /// マネージャ更新
     pInput_->Update();
@@ -208,7 +208,7 @@ void NimaFramework::Draw()
 
     /// UIの描画
     pSpriteSystem_->PresentDraw();
-    UI::DrawUI();
+    NiUI::DrawUI();
 
     /// レンダーターゲットからビューポート用リソースにコピー
     pDirectX_->CopyFromRTV(pDirectX_->GetCommandList());
@@ -243,7 +243,7 @@ void NimaFramework::DrawHighPerformance()
 
     /// 前景スプライトの描画
     pSceneManager_->SceneDraw2dForeground();
-    UI::DrawUI();
+    NiUI::DrawUI();
     pSpriteSystem_->DrawCall();
 
 

--- a/Engine/Framework/NimaFramework.h
+++ b/Engine/Framework/NimaFramework.h
@@ -20,7 +20,7 @@
 #include <Features/RandomGenerator/RandomGenerator.h>
 #include <Features/Text/TextSystem.h>
 #include <Features/Viewport/Viewport.h>
-#include <Features/UI/Derived/Drawer.h>
+#include <Features/NiUI/Derived/Drawer.h>
 
 #include <memory> /// std::unique_ptr
 

--- a/SampleProject/Scene/GameScene/GameScene.cpp
+++ b/SampleProject/Scene/GameScene/GameScene.cpp
@@ -6,7 +6,7 @@
 #include <Features/Line/LineSystem.h>
 #include <Core/Win32/WinSystem.h>
 #include <Features/GameEye/FreeLook/FreeLookEye.h>
-#include <Features/UI/UI.h>
+#include <Features/NiUI/NiUI.h>
 #include <Features/Audio/AudioManager.h>
 
 
@@ -86,18 +86,18 @@ void GameScene::Update()
     pSmoke_->Update();
     pSpark_->Update();
 
-    if (UI::Button("Button1", "white1x1.png", { 100, 100 }, { 100, 30 }))
+    if (NiUI::Button("Button1", "white1x1.png", { 100, 100 }, { 100, 30 }))
     {
         /// Do anything...
         pAudio_->Play();
     }
 
-    if (UI::Button("Button2", "white1x1.png", { 100, 150 }, { 100, 30 }))
+    if (NiUI::Button("Button2", "white1x1.png", { 100, 150 }, { 100, 30 }))
     {
         /// Do anything...
     }
 
-    if (UI::Button("Button3", "white1x1.png", { 100, 200 }, { 100, 30 }))
+    if (NiUI::Button("Button3", "white1x1.png", { 100, 200 }, { 100, 30 }))
     {
         /// Do anything...
     }


### PR DESCRIPTION
## WinSystem.cpp
- `#include <Features/UI/UI.h>` を `#include <Features/NiUI/NiUI.h>` に変更
- `UI::NiUI_WndProcHandler` を `NiUI::NiUI_WndProcHandler` に変更

## Drawer.h
- `#include <Features/UI/Interface/IDrawer.h>` を `#include <Features/NiUI/Interface/NiUI_IDrawer.h>` に変更

## NiUI_IDrawer.cpp
- `#include "IDrawer.h"` を `#include "NiUI_IDrawer.h"` に変更

## NiUI_IDrawer.h
- `#include "../Type/ComponentData.h"` を `#include "../Type/NiUI_ComponentData.h"` に変更

## NiUI.cpp
- `#include "UI.h"` を `#include "NiUI.h"` に変更
- `UI` クラスのメンバ変数やメソッドを `NiUI` クラスに変更

## NiUI.h
- `#include "Type/ComponentData.h"` を `#include "Type/NiUI_ComponentData.h"` に変更
- `#include "UI_Input.h"` を `#include "NiUI_Input.h"` に変更
- `#include "Interface/IDrawer.h"` を `#include "Interface/NiUI_IDrawer.h"` に変更
- `UI` クラスを `NiUI` クラスに変更

## NiUI_Input.cpp
- `#include "UI_Input.h"` を `#include "NiUI_Input.h"` に変更
- `UI_Input` クラスのメソッドを `NiUI_Input` クラスに変更

## NiUI_Input.h
- `UI_Input` クラスを `NiUI_Input` クラスに変更
- `MouseData` 構造体を `NiUI_Input` クラス内に移動

## NiUI_ComponentData.h
- `#include "UIEnum.h"` を `#include "NiUI_Enum.h"` に変更

## NimaFramework.cpp
- `#include <Features/UI/UI.h>` を `#include <Features/NiUI/NiUI.h>` に変更
- `UI` クラスのメソッドを `NiUI` クラスに変更

## NimaFramework.h
- `#include <Features/UI/Derived/Drawer.h>` を `#include <Features/NiUI/Derived/Drawer.h>` に変更

## GameScene.cpp
- `#include <Features/UI/UI.h>` を `#include <Features/NiUI/NiUI.h>` に変更
- `UI::Button` を `NiUI::Button` に変更