### PR TITLE
デバッグモードでのウィンドウ情報設定関数の変更

### DIFF
--- a/Engine/Framework/NimaFramework.cpp
+++ b/Engine/Framework/NimaFramework.cpp
@@ -153,7 +153,7 @@ void NimaFramework::Update()
     /// UIの更新
     #ifdef _DEBUG
 
-    UI::SetWindowInfo(
+    NiUI::SetWindowInfo(
         { pViewport_->GetViewportSize().x, pViewport_->GetViewportSize().y },
         { pViewport_->GetViewportPos().x, pViewport_->GetViewportPos().y }
     );


### PR DESCRIPTION
## 変更内容

### NimaFramework

* `NimaFramework.cpp` の `NimaFramework::Update()` 関数内で、`UI::SetWindowInfo` 関数の呼び出しが `NiUI::SetWindowInfo` 関数の呼び出しに変更されました。この変更はデバッグモード (`#ifdef _DEBUG` ブロック内) で行われています。