### PR TITLE
improve: ビューポートとデバッグ機能の整理と強化

### DIFF
--- a/Engine/Core/DirectX12/DirectX12_Impl.cpp
+++ b/Engine/Core/DirectX12/DirectX12_Impl.cpp
@@ -364,26 +364,12 @@ void DirectX12::CreateFenceAndEvent()
 void DirectX12::SetViewportAndScissorRect()
 {
     /// ビューポート
-#ifdef _DEBUG
-        // クライアント領域のサイズと一緒にして画面全体に表示
-    viewport_.Width = static_cast<FLOAT>(1120);
-    viewport_.Height = static_cast<FLOAT>(630);
-    viewport_.TopLeftX = 130;
-    viewport_.TopLeftY = 40;
-    viewport_.MinDepth = 0.0f;
-    viewport_.MaxDepth = 1.0f;
-
-#else
     viewport_.Width = static_cast<FLOAT>(clientWidth_);
     viewport_.Height = static_cast<FLOAT>(clientHeight_);
     viewport_.TopLeftX = 0;
     viewport_.TopLeftY = 0;
     viewport_.MinDepth = 0.0f;
     viewport_.MaxDepth = 1.0f;
-#endif // _DEBUG
-
-
-
 
     /// シザー矩形
     // 基本的にビューポートと同じ矩形が構成されるようにする

--- a/Engine/Features/Text/Text.h
+++ b/Engine/Features/Text/Text.h
@@ -74,6 +74,7 @@ private: /// 借り物
     IDWriteFactory7*                            dwriteFactory_              = nullptr;
     TextSystem*                                 pTextSystem_                = nullptr;
     ID2D1DeviceContext2*                        d2dDeviceContext_           = nullptr;
+    Viewport*                                   pViewport_                  = nullptr;
 
 
 private: /// デバッグ

--- a/Engine/Features/Text/TextSystem.h
+++ b/Engine/Features/Text/TextSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/DirectX12/DirectX12.h>
+#include <Features/Viewport/Viewport.h>
 
 #include <wrl.h>
 #include <dwrite.h>
@@ -28,6 +29,7 @@ public:
 
 public:
     void SetColorBrush(const std::string _key, const D2D1::ColorF& _color);
+    void SetViewport(Viewport* _viewport) { pViewport_ = _viewport; }
 
 
 public: /// Getter
@@ -35,6 +37,7 @@ public: /// Getter
     IDWriteTextFormat* GetTextFormat(const std::string& _fontFamily, float _fontSize);
     ID2D1SolidColorBrush* GetColorBrush(const std::string& _key);
     ID2D1DeviceContext2* GetD2D1DeviceContext() const { return d2dDeviceContext_; }
+    Viewport* GetViewport() const { return pViewport_; }
 
 
 private:
@@ -60,4 +63,5 @@ private: /// 借り物
     ID2D1DeviceContext2* d2dDeviceContext_ = nullptr;
     ID3D11On12Device* d3d11On12Device_ = nullptr;
     ID3D11DeviceContext* d3d11On12DeviceContext_ = nullptr;
+    Viewport* pViewport_ = nullptr;
 };

--- a/Engine/Features/Viewport/Viewport.cpp
+++ b/Engine/Features/Viewport/Viewport.cpp
@@ -214,16 +214,25 @@ void Viewport::DrawWindow()
 
     if(ImGui::Begin("Viewport", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoBringToFrontOnFocus))
     {
-        auto pos = ImGui::GetWindowPos();
-        windowPos_ = { pos.x, pos.y };
+        //auto pos = ImGui::GetWindowPos();
+        //windowPos_ = { pos.x, pos.y };
 
-        auto wndSize = ImGui::GetWindowSize();
-        vpSize_ = { wndSize.x, wndSize.y };
+        //auto wndSize = ImGui::GetWindowSize();
+        //vpSize_ = { wndSize.x, wndSize.y };
 
-        ImGui::Image((ImTextureID)gpuHnd.ptr, ImVec2(static_cast<float>(width), static_cast<float>(height)));
+        auto cliSize = ImGui::GetContentRegionAvail();
+
+        float aspect = static_cast<float>(width) / static_cast<float>(height);
+
+        ImVec2 imageSizeAdjusted = cliSize;
+        imageSizeAdjusted.x = imageSizeAdjusted.y * aspect;
+
+        ImGui::Image((ImTextureID)gpuHnd.ptr, imageSizeAdjusted);
 
         auto itempos = ImGui::GetItemRectMin();
         vpPos_ = { itempos.x, itempos.y };
+        auto itemsize = ImGui::GetItemRectSize();
+        vpSize_ = { itemsize.x, itemsize.y };
     }
     ImGui::End();
 

--- a/Engine/Features/Viewport/Viewport.cpp
+++ b/Engine/Features/Viewport/Viewport.cpp
@@ -222,7 +222,11 @@ void Viewport::DrawWindow()
 
         auto cliSize = ImGui::GetContentRegionAvail();
 
-        float aspect = static_cast<float>(width) / static_cast<float>(height);
+        float aspect = 1.0f; // Default aspect ratio
+        if (height != 0)
+        {
+            aspect = static_cast<float>(width) / static_cast<float>(height);
+        }
 
         ImVec2 imageSizeAdjusted = cliSize;
         imageSizeAdjusted.x = imageSizeAdjusted.y * aspect;

--- a/Engine/Framework/NimaFramework.cpp
+++ b/Engine/Framework/NimaFramework.cpp
@@ -108,6 +108,7 @@ void NimaFramework::Initialize()
     /// ビューポートの初期化
     pViewport_ = std::make_unique<Viewport>();
     pViewport_->Initialize();
+    pTextSystem_->SetViewport(pViewport_.get());
 
     /// シーンマネージャの初期化
     pSceneManager_->Initialize();


### PR DESCRIPTION
### DirectX12_Impl
- `DirectX12::SetViewportAndScissorRect()` メソッドにおいて、`_DEBUG` マクロが有効な場合のビューポート設定を削除し、`clientWidth_` と `clientHeight_` を使用するコードに統一。
- シザー矩形の設定に関するコメントを整理。

### Text
- `Text.cpp` において、`_DEBUG` マクロが有効な場合に `Viewport` を利用するコードを追加。
  - `Text::Initialize()` メソッドで `Viewport` のインスタンスを取得。
  - `Text::Update()` メソッドでデバッグ時に `UpdatePosition()` を呼び出す処理を追加。
  - `Text::SetPosition()` メソッドでデバッグ時に `Viewport` の位置とサイズを使用してスクリーン座標を計算する処理を追加。
- `Text::DebugWindow()` メソッドで、テキスト変更時に `isChanged_` フラグを `true` に設定する処理を追加。
- `Text.h` に `Viewport* pViewport_` メンバーを追加。

### TextSystem
- `TextSystem.h` において、`Viewport` を管理するためのヘッダーインクルードを追加。
- `SetViewport()` メソッドと `GetViewport()` メソッドを追加。
- `Viewport* pViewport_` メンバーを追加。

### Viewport
- `Viewport.cpp` の `Viewport::DrawWindow()` メソッドで、ウィンドウの位置やサイズを取得するコードをコメントアウト。
  - コンテンツ領域のサイズを基にアスペクト比を調整して画像を描画する処理を追加。
  - `vpPos_` と `vpSize_` の計算方法を変更。

### NimaFramework
- `NimaFramework::Initialize()` メソッドで、`TextSystem` に `Viewport` を設定する処理を追加。

### 概要
- ビューポートとシザー矩形の設定を整理し、デバッグ時と通常時の挙動を統一。
- `Viewport` クラスが `TextSystem` や `Text` クラスと連携するように変更。
- デバッグ時にビューポートの位置やサイズを利用する機能を追加。
- `Viewport` の描画処理を改善し、アスペクト比を考慮した画像描画を実現。
- 全体的にデバッグ機能の強化とコードの整理を実施。