### PR TITLE
feat: 設定管理機能を追加し、各モジュールを更新

### DIFF
--- a/Engine/Core/ConfigManager/ConfigManager.cpp
+++ b/Engine/Core/ConfigManager/ConfigManager.cpp
@@ -1,0 +1,19 @@
+#include "ConfigManager.h"
+
+#include <Utility/JSONIO/JSONIO.h>
+
+void ConfigManager::Initialize(const std::string& _cfgPath)
+{
+    LoadConfig(_cfgPath);
+}
+
+const cfg::ConfigData& ConfigManager::GetConfigData() const
+{
+    return configData_;
+}
+
+void ConfigManager::LoadConfig(const std::string& _cfgPath)
+{
+    auto& j = JSONIO::GetInstance()->Load(_cfgPath);
+    configData_ = j;
+}

--- a/Engine/Core/ConfigManager/ConfigManager.h
+++ b/Engine/Core/ConfigManager/ConfigManager.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "./ConfigType.h"
+#include <ClassStyles/SingletonStyle.h>
+#include <string>
+
+class ConfigManager : public SingletonStyle<ConfigManager>
+{
+    friend class SingletonStyle<ConfigManager>;
+public:
+    // Common functions
+    void Initialize(const std::string& _cfgPath);
+    
+    // Getters
+    const cfg::ConfigData& GetConfigData() const;
+
+private:
+    // Internal functions
+    void LoadConfig(const std::string& _cfgPath);
+
+    // Config data
+    cfg::ConfigData configData_ = {};
+};

--- a/Engine/Core/ConfigManager/ConfigType.cpp
+++ b/Engine/Core/ConfigManager/ConfigType.cpp
@@ -1,0 +1,32 @@
+#include "ConfigType.h"
+
+void cfg::to_json(nlohmann::json& _j, const cfg::ConfigData& _c)
+{
+    auto& common = _j["settings"]["common"];
+    auto& path = _j["settings"]["path"];
+
+    common["window_title"] = _c.window_title;
+    common["start_scene"] = _c.start_scene;
+    common["screen_width"] = _c.screen_width;
+    common["screen_height"] = _c.screen_height;
+
+    path["model"] = _c.model_paths;
+    path["texture"] = _c.texture_paths;
+    path["audio"] = _c.audio_paths;
+}
+
+void cfg::from_json(const nlohmann::json& _j, cfg::ConfigData& _c)
+{
+    using namespace utl::json;
+    auto& common = _j.at("settings").at("common");
+    auto& path = _j.at("settings").at("path");
+
+    try_assign(common, "window_title", _c.window_title);
+    try_assign(common, "start_scene", _c.start_scene);
+    try_assign(common, "screen_width", _c.screen_width);
+    try_assign(common, "screen_height", _c.screen_height);
+
+    try_assign(path, "model", _c.model_paths);
+    try_assign(path, "texture", _c.texture_paths);
+    try_assign(path, "audio", _c.audio_paths);
+}

--- a/Engine/Core/ConfigManager/ConfigType.h
+++ b/Engine/Core/ConfigManager/ConfigType.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <string>
+#include <list>
+
+#include <nlohmann/json.hpp>
+#include <Utility/JSON/jsonutl.h>
+
+namespace cfg
+{
+    struct ConfigData
+    {
+        std::string window_title;
+        uint32_t screen_width;
+        uint32_t screen_height;
+        std::string start_scene;
+
+        std::list<std::string> model_paths;
+        std::list<std::string> texture_paths;
+        std::list<std::string> audio_paths;
+    };
+
+    void to_json(nlohmann::json& _j, const cfg::ConfigData& _c);
+    void from_json(const nlohmann::json& _j, cfg::ConfigData& _c);
+}

--- a/Engine/Core/DirectX12/TextureManager.cpp
+++ b/Engine/Core/DirectX12/TextureManager.cpp
@@ -2,13 +2,19 @@
 #include "DirectX12.h"
 #include <Core/DirectX12/Helper/DX12Helper.h>
 #include <Utility/ConvertString/ConvertString.h>
-
+#include <Core/ConfigManager/ConfigManager.h>
 
 
 void TextureManager::Initialize(SRVManager* _srvManager)
 {
     srvManager_ = _srvManager;
     textureDataMap_.reserve(DirectX12::kMaxSRVCount_);
+
+    auto& cfgData = ConfigManager::GetInstance()->GetConfigData();
+    for (auto& path : cfgData.texture_paths)
+    {
+        this->AddSearchPath(path);
+    }
 }
 
 void TextureManager::LoadTexture(const std::string& _filePath)

--- a/Engine/Core/Win32/WinSystem.cpp
+++ b/Engine/Core/Win32/WinSystem.cpp
@@ -2,6 +2,8 @@
 #include <cassert>
 
 #include <NiGui/NiGui.h>
+#include <Core/ConfigManager/ConfigManager.h>
+#include <Utility/ConvertString/ConvertString.h>
 
 #ifdef _DEBUG
 #include <imgui.h>
@@ -27,6 +29,11 @@ void WinSystem::Initialize()
     wc_.hInstance = GetModuleHandle(nullptr);
     wc_.hCursor = LoadCursor(nullptr, IDC_ARROW);
     RegisterClass(&wc_);
+
+    auto& cfgData = ConfigManager::GetInstance()->GetConfigData();
+    clientWidth = cfgData.screen_width;
+    clientHeight = cfgData.screen_height;
+    title_ = ConvertString(cfgData.window_title);
 }
 
 void WinSystem::Finalize() const
@@ -41,7 +48,7 @@ void WinSystem::ShowWnd()
     AdjustWindowRect(&wrc, WS_OVERLAPPEDWINDOW, false);
     hwnd_ = CreateWindow(
         wc_.lpszClassName,          // 利用するクラス名
-        L"LE2B_17_ナイトウ_ソウト",    // タイトルバーの文字
+        title_.c_str(),             // タイトルバーの文字
         WS_OVERLAPPEDWINDOW,        // よく見るウィンドウスタイル
         CW_USEDEFAULT,              // 表示X座標(ウィンドウ出現位置？)
         CW_USEDEFAULT,              // 表示Y座標

--- a/Engine/Core/Win32/WinSystem.h
+++ b/Engine/Core/Win32/WinSystem.h
@@ -2,6 +2,7 @@
 
 #include <Windows.h>
 #include <cstdint>
+#include <string>
 
 class WinSystem
 {
@@ -34,10 +35,11 @@ private:
 
     static LRESULT __stdcall WindowProcedure(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam);
 
-    WNDCLASS    wc_         = {};
-    HWND        hwnd_       = {};
-    MSG         msg_        = {};
-    RECT        wndSize_    = {};
+    WNDCLASS        wc_         = {};
+    HWND            hwnd_       = {};
+    MSG             msg_        = {};
+    RECT            wndSize_    = {};
+    std::wstring    title_      = {};
     static bool isMoving_;
     static bool isResized_;
 };

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -190,6 +190,8 @@
   <ItemGroup>
     <ClCompile Include="BaseClasses\ObjectSystemBase.cpp" />
     <ClCompile Include="Common\HRESULT_ASSERT.cpp" />
+    <ClCompile Include="Core\ConfigManager\ConfigManager.cpp" />
+    <ClCompile Include="Core\ConfigManager\ConfigType.cpp" />
     <ClCompile Include="Core\DirectX12\BlendMode.cpp" />
     <ClCompile Include="Core\DirectX12\DirectX12.cpp" />
     <ClCompile Include="Core\DirectX12\DirectX12_Impl.cpp" />
@@ -258,6 +260,8 @@
     <ClInclude Include="Common\define.h" />
     <ClInclude Include="Common\HRESULT_ASSERT.h" />
     <ClInclude Include="Common\structs.h" />
+    <ClInclude Include="Core\ConfigManager\ConfigManager.h" />
+    <ClInclude Include="Core\ConfigManager\ConfigType.h" />
     <ClInclude Include="Core\DirectX12\BlendMode.h" />
     <ClInclude Include="Core\DirectX12\DirectX12.h" />
     <ClInclude Include="Core\DirectX12\Framerate.h" />

--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -226,6 +226,9 @@
     <Filter Include="Utility\JSON">
       <UniqueIdentifier>{e3866255-e1bd-474c-adaa-9fa7dec28d9c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Core\ConfigManager">
+      <UniqueIdentifier>{fafd37d8-141a-4074-80f2-64b9aa3be79f}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DebugTools\DebugManager\DebugManager.cpp">
@@ -417,6 +420,10 @@
     <ClCompile Include="Type\Color.cpp">
       <Filter>Type</Filter>
     </ClCompile>
+    <ClCompile Include="Core\ConfigManager\ConfigManager.cpp">
+      <Filter>Core\ConfigManager</Filter>
+    </ClCompile>
+    <ClCompile Include="Core\ConfigManager\ConfigType.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\define.h">
@@ -652,6 +659,12 @@
     </ClInclude>
     <ClInclude Include="Utility\JSON\jsonutl.h">
       <Filter>Utility\JSON</Filter>
+    </ClInclude>
+    <ClInclude Include="Core\ConfigManager\ConfigManager.h">
+      <Filter>Core\ConfigManager</Filter>
+    </ClInclude>
+    <ClInclude Include="Core\ConfigManager\ConfigType.h">
+      <Filter>Core\ConfigManager</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Engine/Features/Audio/AudioManager.cpp
+++ b/Engine/Features/Audio/AudioManager.cpp
@@ -1,5 +1,7 @@
 #include "AudioManager.h"
 
+#include <Core/ConfigManager/ConfigManager.h>
+
 #include <cassert>
 
 void AudioManager::Initialize()
@@ -9,7 +11,13 @@ void AudioManager::Initialize()
 
     pFilePathSearcher_ = std::make_unique<FilePathSearcher>();
     pFilePathSearcher_->Initialize();
-    pFilePathSearcher_->AddSearchPath("Resources/Sounds/");
+
+    // 設定ファイルからパスを取得して登録
+    auto& cfgData = ConfigManager::GetInstance()->GetConfigData();
+    for (auto& path : cfgData.audio_paths)
+    {
+        this->AddSearchPath(path);
+    }
 }
 
 void AudioManager::Update()
@@ -38,6 +46,11 @@ void AudioManager::Update()
 void AudioManager::Finalize()
 {
     pXAudio2_.Reset();
+}
+
+void AudioManager::AddSearchPath(const std::string& _path)
+{
+    pFilePathSearcher_->AddSearchPath(_path);
 }
 
 Audio* AudioManager::GetNewAudio(const std::string& _filename)

--- a/Engine/Features/Audio/AudioManager.h
+++ b/Engine/Features/Audio/AudioManager.h
@@ -2,9 +2,9 @@
 
 #include "Audio.h"
 #include <Utility/FilePathSearcher/FilePathSearcher.h>
-#include <vector>
 #include <map>
 #include <list>
+#include <string>
 
 class AudioManager
 {
@@ -26,8 +26,13 @@ public:
     void Update();
     void Finalize();
 
+    /// <summary>
+    /// 検索パスを追加
+    /// </summary>
+    /// <param name="_path">パス</param>
+    void AddSearchPath(const std::string& _path);
+
     void AddSourceVoice(IXAudio2SourceVoice* _sv) { sourceVoices_.push_back(_sv); }
-    
     Audio* GetNewAudio(const std::string& _filename);
 
 

--- a/Engine/Features/Model/ModelManager.cpp
+++ b/Engine/Features/Model/ModelManager.cpp
@@ -1,12 +1,18 @@
 #include "ModelManager.h"
-#include <Features/Model/Helper/ModelHelper.h>
+
+#include <Core/ConfigManager/ConfigManager.h>
 #include <filesystem>
-#include <Features/Particle/Particle.h>
 #include <algorithm>
 #include <cctype>
 
 void ModelManager::Initialize()
 {
+    // Configに記述されているフォルダの追加
+    auto& cfgData = ConfigManager::GetInstance()->GetConfigData();
+    for (auto& path : cfgData.model_paths)
+    {
+        this->AddAutoLoadPath(path);
+    }
 }
 
 void ModelManager::AddSearchPath(const std::string& _path)

--- a/Engine/Features/Particle/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Particle/Emitter/ParticleEmitter.cpp
@@ -203,10 +203,8 @@ void ParticleEmitter::DebugWindow()
 
     char path[512] = "";
     char name[128] = "";
-    strncpy_s(path, jsonPath_.c_str(), sizeof(path) - 1);
-    path[sizeof(path) - 1] = '\0'; // Ensure null termination
-    strncpy_s(name, fromJsonData_.name_.c_str(), sizeof(name) - 1);
-    name[sizeof(name) - 1] = '\0'; // Ensure null termination
+    memcpy_s(path, sizeof(name), jsonPath_.c_str(), jsonPath_.size());
+    memcpy_s(name, sizeof(name), fromJsonData_.name_.c_str(), fromJsonData_.name_.size());
 
     ImGui::Text("Name : %s", particleName_.c_str());
     if (ImGui::CollapsingHeader("一般"))

--- a/Engine/Features/SceneManager/SceneManager.cpp
+++ b/Engine/Features/SceneManager/SceneManager.cpp
@@ -2,6 +2,7 @@
 
 #include <imgui.h>
 #include <DebugTools/DebugManager/DebugManager.h>
+#include <Core/ConfigManager/ConfigManager.h>
 
 #include <cassert>
 
@@ -13,9 +14,16 @@ void SceneManager::ReserveScene(const std::string& _name)
     return;
 }
 
+void SceneManager::ReserveStartupScene()
+{
+    auto& cfgData = ConfigManager::GetInstance()->GetConfigData();
+    this->ReserveScene(cfgData.start_scene);
+}
+
 void SceneManager::Initialize()
 {
     DebugManager::GetInstance()->SetComponent("#Window", name_, std::bind(&SceneManager::DebugWindow, this));
+    ReserveStartupScene();
 }
 
 void SceneManager::Update()

--- a/Engine/Features/SceneManager/SceneManager.h
+++ b/Engine/Features/SceneManager/SceneManager.h
@@ -26,6 +26,7 @@ public: /// Setter
 
 public:
     void ReserveScene(const std::string& _sceneName);
+    void ReserveStartupScene();
 
 
 public: /// シーン動作

--- a/Engine/Framework/NimaFramework.cpp
+++ b/Engine/Framework/NimaFramework.cpp
@@ -38,6 +38,7 @@ void NimaFramework::Run()
 void NimaFramework::Initialize()
 {
     /// システムクラスの初期化
+    pConfigManager_ = ConfigManager::GetInstance();
     pLogger_ = Logger::GetInstance();
     pDirectX_ = DirectX12::GetInstance();
 
@@ -61,6 +62,9 @@ void NimaFramework::Initialize()
     #ifdef _DEBUG
     pImGuiManager_ = std::make_unique<ImGuiManager>();
     #endif // _DEBUG
+
+    // 設定ファイルの読み込み
+    pConfigManager_->Initialize("resources/json/.engine/config.json");
 
     /// ロガーの初期化
     pLogger_->Initialize();

--- a/Engine/Framework/NimaFramework.h
+++ b/Engine/Framework/NimaFramework.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/ConfigManager/ConfigManager.h>
 #include <DebugTools/Logger/Logger.h>
 #include <Features/Audio/AudioManager.h>
 #include <Features/Input/Input.h>
@@ -62,6 +63,7 @@ protected: /// システムクラスのインスタンス
 
 
 protected: /// 他クラスのインスタンス
+    ConfigManager*                  pConfigManager_             = nullptr;
     Logger*                         pLogger_                    = nullptr;
     DirectX12*                      pDirectX_                   = nullptr;
     DebugManager*                   pDebugManager_              = nullptr;

--- a/SampleProject/Resources/Json/.engine/config.json
+++ b/SampleProject/Resources/Json/.engine/config.json
@@ -1,0 +1,15 @@
+{
+    "settings": {
+        "common": {
+            "window_title": "Nima Engine",
+            "start_scene" : "CG4Task1",
+            "screen_width": 1600,
+            "screen_height": 900
+        },
+        "path" : {
+            "model" : ["Resources/Models", "Resources/Temp"],
+            "texture" : ["Resources/Images"],
+            "audio" : ["Resources/Sounds"]
+        }
+    }
+}

--- a/SampleProject/SampleProgram/SampleProgram.cpp
+++ b/SampleProject/SampleProgram/SampleProgram.cpp
@@ -8,24 +8,12 @@ void SampleProgram::Initialize()
     /// 基底クラスの初期化処理
     NimaFramework::Initialize();
 
-
     /// シーンファクトリの設定
     pSceneFactory_ = std::make_unique<SceneFactory>();
     pSceneManager_->SetSceneFactory(pSceneFactory_.get());
 
-
-    /// 自動ロードパスの追加
-    pModelManager_->AddAutoLoadPath("resources/models");
-    pModelManager_->AddAutoLoadPath("resources/temp");
-    pTextureManager_->AddSearchPath("resources/images");
-
-
     /// モデルを全てロード
     pModelManager_->LoadAllModel();
-
-
-    /// シーンの生成
-    pSceneManager_->ReserveScene("GameScene");
 }
 
 void SampleProgram::Finalize()


### PR DESCRIPTION
- **TextureManager**
  - `ConfigManager` から取得した設定データを使用してテクスチャの検索パスを設定する機能を追加。

- **WinSystem**
  - ウィンドウの初期化時に設定データからクライアントの幅、高さ、タイトルを取得する処理を追加。

- **AudioManager**
  - `ConfigManager` から取得した設定データを使用してオーディオの検索パスを設定する機能を追加。

- **ModelManager**
  - `ConfigManager` から取得した設定データを使用してモデルの自動ロードパスを設定する機能を追加。

- **SceneManager**
  - `ConfigManager` から取得した設定データを使用してスタートアップシーンを予約する機能を追加。

- **NimaFramework**
  - 設定ファイルを読み込む処理を追加し、`ConfigManager` のインスタンスを初期化。

- **ConfigManager**
  - 新たに追加され、設定ファイルの読み込みやデータの取得を行うメソッドを実装。

- **ConfigType**
  - 設定データを JSON 形式に変換する関数を追加し、設定データの構造体を定義。

- **config.json**
  - ウィンドウタイトル、スタートシーン、画面サイズ、モデル、テクスチャ、オーディオのパスを定義した設定ファイルを追加。

- **プロジェクトファイル**
  - `Engine.vcxproj` と `Engine.vcxproj.filters` に `ConfigManager` に関連するソースファイルとヘッダーファイルを追加。

- **SampleProgram**
  - 初期化処理を簡略化し、設定ファイルからのパス追加処理を削除。

- **バイナリファイル**
  - `config.json` を追加し、設定情報を管理。