### PR TITLE
feat: パーティクルエミッタのデータ構造を更新

### DIFF
--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -420,9 +420,6 @@
     <ClCompile Include="DebugTools\EventTimer\EventTimer.cpp">
       <Filter>DebugTools\EventTimer</Filter>
     </ClCompile>
-    <ClCompile Include="Features\Particle\Emitter\EmitterData.cpp">
-      <Filter>Feature\Particle\Emitter</Filter>
-    </ClCompile>
     <ClCompile Include="Utility\JSONIO\JSONIO.cpp">
       <Filter>Utility\JSONIO</Filter>
     </ClCompile>
@@ -437,6 +434,9 @@
     </ClCompile>
     <ClCompile Include="Core\ConfigManager\ConfigType.cpp">
       <Filter>Core\ConfigManager</Filter>
+    </ClCompile>
+    <ClCompile Include="Features\Particle\Emitter\EmitterData.cpp">
+      <Filter>Feature\Particle\Emitter</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -656,9 +656,6 @@
     <ClInclude Include="DebugTools\EventTimer\EventTimer.h">
       <Filter>DebugTools\EventTimer</Filter>
     </ClInclude>
-    <ClInclude Include="Features\Particle\Emitter\EmitterData.h">
-      <Filter>Feature\Particle\Emitter</Filter>
-    </ClInclude>
     <ClInclude Include="Utility\JSONConvTypeFuncs\JSONConvTypeFuncs.h">
       <Filter>Utility\JSONConvTypeFuncs</Filter>
     </ClInclude>
@@ -688,6 +685,9 @@
     </ClInclude>
     <ClInclude Include="Core\DirectX12\ResourceStateTracker\ResourceStateTracker.h">
       <Filter>Core\DirectX12\ResourceStateTracker</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\Particle\Emitter\EmitterData.h">
+      <Filter>Feature\Particle\Emitter</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Engine/Features/Particle/Emitter/EmitterData.cpp
+++ b/Engine/Features/Particle/Emitter/EmitterData.cpp
@@ -193,3 +193,126 @@ namespace Type::ParticleEmitter::v2
         j_flag["enableScaleTransition"]         = d_flag.enableScaleTransition;
     }
 }
+
+namespace Type::ParticleEmitter::v3
+{
+    Data::Data(const Type::ParticleEmitter::v1::Data& _rv)
+    {
+        *this = v2::Data(_rv);
+    }
+
+    Data::Data(const Type::ParticleEmitter::v2::Data& _rv)
+    {
+        name = _rv.name;
+        common.v2::Common::operator=(_rv.common);
+        ranges = _rv.ranges;
+        physics.v2::PhysicsData::operator=(_rv.physics);
+        flags.v2::Flags::operator=(_rv.flags);
+    }
+
+    void from_json(const nlohmann::json& _j, Data& _data)
+    {
+        CheckVersion(_j, _data);
+
+        utl::json::try_assign(_j, "name", _data.name);
+
+        nlohmann::json j_range;  utl::json::try_assign(_j, "ranges", j_range);
+        nlohmann::json j_common;  utl::json::try_assign(_j, "common", j_common);
+        nlohmann::json j_phys;  utl::json::try_assign(_j, "physics", j_phys);
+        nlohmann::json j_flag;  utl::json::try_assign(_j, "flags", j_flag);
+        nlohmann::json j_colflo; utl::json::try_assign(_j, "collisionFloor", j_colflo);
+
+        auto& d_common = _data.common;
+
+        utl::json::try_assign(j_common, "scaleFixed", d_common.scaleFixed);
+        utl::json::try_assign(j_common, "emitInterval", d_common.emitInterval);
+        utl::json::try_assign(j_common, "emitNum", d_common.emitNum);
+        utl::json::try_assign(j_common, "emitterLifeTime", d_common.emitterLifeTime);
+        utl::json::try_assign(j_common, "particleLifeTime", d_common.particleLifeTime);
+        utl::json::try_assign(j_common, "scaleDelayTime", d_common.scaleDelayTime);
+        utl::json::try_assign(j_common, "emitPositionFixed", d_common.emitPositionFixed);
+        utl::json::try_assign(j_common, "alphaDeltaValue", d_common.alphaDeltaValue);
+        utl::json::try_assign(j_common, "velocityFixed", d_common.velocityFixed);
+
+        auto& d_range = _data.ranges;
+
+        utl::json::try_assign(j_range, "scale", d_range.scale);
+        utl::json::try_assign(j_range, "scaleRandom", d_range.scaleRandom);
+        utl::json::try_assign(j_range, "position", d_range.position);
+        utl::json::try_assign(j_range, "color", d_range.color);
+        utl::json::try_assign(j_range, "velocityRandom", d_range.velocityRandom);
+        utl::json::try_assign(j_range, "rotationRandom", d_range.rotationRandom);
+
+        auto& d_phys = _data.physics;
+
+        utl::json::try_assign(j_phys, "gravity", d_phys.gravity);
+        utl::json::try_assign(j_phys, "resistance", d_phys.resistance);
+        utl::json::try_assign(j_phys, "frictionCoef", d_phys.frictionCoef);
+
+        auto& d_flag = _data.flags;
+
+        utl::json::try_assign(j_flag, "enableRandomVelocity", d_flag.enableRandomVelocity);
+        utl::json::try_assign(j_flag, "enableRandomEmit", d_flag.enableRandomEmit);
+        utl::json::try_assign(j_flag, "enableRandomRotation", d_flag.enableRandomRotation);
+        utl::json::try_assign(j_flag, "enableRandomScale", d_flag.enableRandomScale);
+        utl::json::try_assign(j_flag, "enableScaleTransition", d_flag.enableScaleTransition);
+        utl::json::try_assign(j_flag, "enableCollisionFloor", d_flag.enableCollisionFloor);
+
+        auto& d_colFloor = _data.collisionFloor;
+
+        utl::json::try_assign(j_colflo, "elevation", d_colFloor.elevation);
+        utl::json::try_assign(j_colflo, "bouncePower", d_colFloor.bounce_power);
+    }
+
+    void to_json(nlohmann::json& _j, const Data& _data)
+    {
+        _j["version"]                           = 3;                            // Version 3 for this format
+        _j["name"]                              = _data.name;
+
+        auto& j_common  = _j["common"];
+        auto& d_common = _data.common; 
+
+        j_common["scaleFixed"]                  = d_common.scaleFixed;
+        j_common["emitInterval"]                = d_common.emitInterval;
+        j_common["emitNum"]                     = d_common.emitNum;
+        j_common["emitterLifeTime"]             = d_common.emitterLifeTime;
+        j_common["particleLifeTime"]            = d_common.particleLifeTime;
+        j_common["scaleDelayTime"]              = d_common.scaleDelayTime;
+        j_common["emitPositionFixed"]           = d_common.emitPositionFixed;
+        j_common["alphaDeltaValue"]             = d_common.alphaDeltaValue;
+        j_common["velocityFixed"]               = d_common.velocityFixed;
+
+        auto& j_ranges = _j["ranges"];
+        auto& d_ranges = _data.ranges;
+
+        j_ranges["scale"]                       = d_ranges.scale;
+        j_ranges["scaleRandom"]                 = d_ranges.scaleRandom;
+        j_ranges["position"]                    = d_ranges.position;
+        j_ranges["color"]                       = d_ranges.color;
+        j_ranges["velocityRandom"]              = d_ranges.velocityRandom;
+        j_ranges["rotationRandom"]              = d_ranges.rotationRandom;
+
+        auto& j_phys = _j["physics"];
+        auto& d_phys = _data.physics;
+
+        j_phys["gravity"]                       = d_phys.gravity;
+        j_phys["resistance"]                    = d_phys.resistance;
+        j_phys["frictionCoef"]                  = d_phys.frictionCoef;
+
+        auto& j_flag = _j["flags"];
+        auto& d_flag = _data.flags;
+
+        j_flag["enableRandomVelocity"]          = d_flag.enableRandomVelocity;
+        j_flag["enableRandomEmit"]              = d_flag.enableRandomEmit;
+        j_flag["enableRandomRotation"]          = d_flag.enableRandomRotation;
+        j_flag["enableRandomScale"]             = d_flag.enableRandomScale;
+        j_flag["enableScaleTransition"]         = d_flag.enableScaleTransition;
+        j_flag["enableCollisionFloor"]          = d_flag.enableCollisionFloor;
+
+        auto& j_colflo = _j["collisionFloor"];
+        auto& d_colflo = _data.collisionFloor;
+
+        j_colflo["elevation"]                   = d_colflo.elevation;
+        j_colflo["bouncePower"]                 = d_colflo.bounce_power;
+    }
+}

--- a/Engine/Features/Particle/Emitter/EmitterData.h
+++ b/Engine/Features/Particle/Emitter/EmitterData.h
@@ -32,6 +32,18 @@ namespace Type
             void from_json(const nlohmann::json& _j, Data& _data);
             void to_json(nlohmann::json& _j, const Data& _data);
         }
+
+        namespace v3
+        {
+            struct Common;
+            struct Flags;
+            struct PhysicsData;
+            struct CollisionFloor;
+            struct Data;
+
+            void from_json(const nlohmann::json& _j, Data& _data);
+            void to_json(nlohmann::json& _j, const Data& _data);
+        }
     }
 }
 
@@ -66,6 +78,7 @@ struct Type::ParticleEmitter::v1::Data
 
 struct Type::ParticleEmitter::v2::Common
 {
+    Common& operator=(const Common& _rv) = default;
     Vector3         scaleFixed                  = {};                   // 固定スケール
     float           emitInterval                = {};                   // 発生間隔
     int32_t         emitNum                     = {};                   // 発生数
@@ -79,6 +92,7 @@ struct Type::ParticleEmitter::v2::Common
 
 struct Type::ParticleEmitter::v2::Flags
 {
+    Flags& operator=(const Flags&) = default;
     bool            enableRandomVelocity        = {};                   // ランダム速度
     bool            enableRandomEmit            = {};                   // ランダム発生
     bool            enableRandomRotation        = {};                   // ランダム回転
@@ -98,6 +112,7 @@ struct Type::ParticleEmitter::v2::RangeData
 
 struct Type::ParticleEmitter::v2::PhysicsData
 {
+    PhysicsData& operator=(const PhysicsData&) = default;
     Vector3         gravity                     = {};                   // 重力
     Vector3         resistance                  = {};                   // 抵抗
 };
@@ -114,4 +129,39 @@ struct Type::ParticleEmitter::v2::Data
     Flags           flags                       = {};                   // フラグ
 };
 
+struct Type::ParticleEmitter::v3::Common : public v2::Common
+{
+    float           radius                      = 0.0f;
+};
+
+struct Type::ParticleEmitter::v3::PhysicsData : public v2::PhysicsData
+{
+    float           frictionCoef                = 0.0f;                 // 摩擦
+};
+
+struct Type::ParticleEmitter::v3::Flags : v2::Flags
+{
+    bool            enableCollisionFloor        = {};                   // 衝突床
+};
+
+struct Type::ParticleEmitter::v3::CollisionFloor
+{
+    float           elevation                   = 0.0f;
+    float           bounce_power                = 0.0f;
+};
+
+struct Type::ParticleEmitter::v3::Data
+{
+    Data() = default;
+    Data(const Type::ParticleEmitter::v2::Data& _rv);
+    Data(const Type::ParticleEmitter::v1::Data& _rv);
+    
+    static constexpr uint32_t version           = 3;                    // バージョン番号
+    std::string     name                        = {};
+    Common          common                      = {};
+    v2::RangeData   ranges                      = {};
+    PhysicsData     physics                     = {};
+    Flags           flags                       = {};
+    CollisionFloor  collisionFloor              = {};                   // 衝突床データ
+};
 

--- a/Engine/Features/Particle/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Particle/Emitter/ParticleEmitter.cpp
@@ -127,6 +127,9 @@ void ParticleEmitter::EmitParticle()
         datum.transform_.translate = emitterData_.common.emitPositionFixed;
     }
 
+    /// 衝突半径
+    datum.radius = emitterData_.common.radius;
+
     /// スケール
     if (emitterData_.flags.enableRandomScale)
     {
@@ -191,8 +194,14 @@ void ParticleEmitter::EmitParticle()
     datum.alphaDeltaValue_ = emitterData_.common.alphaDeltaValue;
     // 消去条件
     datum.deleteCondition_ = ParticleDeleteCondition::LifeTime;
+    // 物理
     datum.accGravity_ = emitterData_.physics.gravity;
     datum.accResistance_ = emitterData_.physics.resistance;
+    datum.frictionCoef_ = emitterData_.physics.frictionCoef;
+
+    // 衝突床
+    datum.enableCollisionFloor = emitterData_.flags.enableCollisionFloor;
+    datum.collisionFloor_ = emitterData_.collisionFloor;
 
     aabb_->SetMinMax(emitterData_.ranges.position.start(), emitterData_.ranges.position.end());
 }
@@ -300,6 +309,7 @@ void ParticleEmitter::DebugWindow()
     
     if (ImGui::CollapsingHeader("変形"))
     {
+        ImGui::DragFloat("衝突半径", &fromJsonData_.common.radius, 0.01f, FLT_MIN, FLT_MAX);
         if (!fromJsonData_.flags.enableRandomScale && !fromJsonData_.flags.enableScaleTransition)
         {
             ImGui::DragFloat3("スケール", &fromJsonData_.common.scaleFixed.x, 0.01f);
@@ -378,11 +388,23 @@ void ParticleEmitter::DebugWindow()
         ImGui::Spacing();
     }
 
+    if (ImGui::CollapsingHeader("衝突床"))
+    {
+        ImGui::Checkbox("衝突床との判定", &fromJsonData_.flags.enableCollisionFloor);
+        if (fromJsonData_.flags.enableCollisionFloor)
+        {
+            ImGui::DragFloat("高さ", &fromJsonData_.collisionFloor.elevation, 0.01f);
+            ImGui::DragFloat("反発係数", &fromJsonData_.collisionFloor.bounce_power, 0.01f);
+        }
+
+        ImGui::Spacing();
+    }
+
     if (ImGui::CollapsingHeader("物理"))
     {
         ImGui::DragFloat3("重力", &fromJsonData_.physics.gravity.x, 0.01f);
         ImGui::DragFloat3("抵抗", &fromJsonData_.physics.resistance.x, 0.01f);
-
+        ImGui::DragFloat("動摩擦係数", &fromJsonData_.physics.frictionCoef, 0.01f);
     }
 
     jsonPath_ = path;

--- a/Engine/Features/Particle/Emitter/ParticleEmitter.h
+++ b/Engine/Features/Particle/Emitter/ParticleEmitter.h
@@ -39,7 +39,7 @@ public: /// Getter
     //EmitterData& GetEmitterData() { return emitterData_; }
 
 private:
-    using EmitterData = Type::ParticleEmitter::v2::Data;
+    using EmitterData = Type::ParticleEmitter::v3::Data;
 
     static constexpr uint32_t   kDefaultReserveCount_   = 6000u;
     std::string                 name_                   = {};               // 名前

--- a/Engine/Features/Particle/Manager/EmitterManager.cpp
+++ b/Engine/Features/Particle/Manager/EmitterManager.cpp
@@ -1,6 +1,6 @@
 #include "EmitterManager.h"
 
-using EmitterData = Type::ParticleEmitter::v2::Data;
+using EmitterData = Type::ParticleEmitter::v3::Data;
 
 const EmitterData& EmitterManager::LoadFile(const std::string& _path)
 {
@@ -38,6 +38,9 @@ void EmitterManager::Deserialize(const json& _root, EmitterData& _data)
         break;
     case 2:
         _data = Type::ParticleEmitter::v2::Data(_root);
+        break;
+    case 3:
+        _data = Type::ParticleEmitter::v3::Data(_root);
         break;
 
     default: break;

--- a/Engine/Features/Particle/Manager/EmitterManager.h
+++ b/Engine/Features/Particle/Manager/EmitterManager.h
@@ -12,7 +12,7 @@ class EmitterManager
 {
 public:
     using json = nlohmann::json;
-    using EmitterData = Type::ParticleEmitter::v2::Data;
+    using EmitterData = Type::ParticleEmitter::v3::Data;
 
     EmitterManager(const EmitterManager&) = delete;
     EmitterManager& operator=(const EmitterManager&) = delete;

--- a/Engine/Features/Particle/Particle.h
+++ b/Engine/Features/Particle/Particle.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "./Type/ParticleType.h"
 #include <Core/DirectX12/DirectX12.h>
 #include <Common/structs.h>
 #include <Features/Model/Model.h>
@@ -11,6 +10,9 @@
 #include <string>
 #include <d3d12.h>
 #include <Matrix4x4.h>
+#include <Vector3.h>
+#include "./Type/ParticleType.h"
+#include "./Emitter/EmitterData.h"
 
 class Particle
 {
@@ -89,10 +91,11 @@ private:
     void DebugWindow();
     float EaseOutCubic(float t);
     float EaseOutQuad(float t);
+    bool UpdateByCollisionFloor(Vector3& _position, Vector3& _velocity, const v3::CollisionFloor& _floor, float _radius);
+    void ApplyFriction(Vector3& _velocity, bool _isGround, float _frictionCoef, float _deltaTime);
 
 private: /// delete condition
     bool ParticleDeleteByCondition(std::vector<ParticleData>::iterator& _itr);
     bool DeleteByLifeTime(std::vector<ParticleData>::iterator& _itr);
     bool DeleteByZeroAlpha(std::vector<ParticleData>::iterator& _itr);
-
 };

--- a/Engine/Features/Particle/Type/ParticleType.h
+++ b/Engine/Features/Particle/Type/ParticleType.h
@@ -4,6 +4,9 @@
 #include <Range.h>
 #include <Vector3.h>
 #include <Vector4.h>
+#include "../Emitter/EmitterData.h"
+
+using namespace  Type::ParticleEmitter;
 
 enum class ParticleDeleteCondition
 {
@@ -26,6 +29,10 @@ struct ParticleData
     Vector3                                 accResistance_      = {};
     Vector3                                 accGravity_         = {};
     Vector3                                 velocity_           = {};
+    float                                   frictionCoef_       = {};
     bool                                    enableDirectionByVelocity = false;
+    bool                                    enableCollisionFloor = false;
+    float                                   radius              = 0.0f;
+    v3::CollisionFloor                      collisionFloor_     = {};
     ParticleDeleteCondition                 deleteCondition_    = ParticleDeleteCondition::LifeTime;
 };

--- a/SampleProject/Resources/Json/Rain.json
+++ b/SampleProject/Resources/Json/Rain.json
@@ -1,8 +1,12 @@
 {
+    "collisionFloor": {
+        "bouncePower": 0.10999999940395355,
+        "elevation": 0.0
+    },
     "common": {
         "alphaDeltaValue": 0.0,
         "emitInterval": 0.20000000298023224,
-        "emitNum": 7,
+        "emitNum": 39,
         "emitPositionFixed": {
             "x": 0.0,
             "y": 3.0199999809265137,
@@ -23,6 +27,7 @@
         }
     },
     "flags": {
+        "enableCollisionFloor": true,
         "enableRandomEmit": true,
         "enableRandomRotation": false,
         "enableRandomScale": false,
@@ -31,6 +36,7 @@
     },
     "name": "Rain",
     "physics": {
+        "frictionCoef": 0.0,
         "gravity": {
             "x": 0.0,
             "y": -2.140000104904175,
@@ -118,5 +124,5 @@
             }
         }
     },
-    "version": 2
+    "version": 3
 }

--- a/SampleProject/Resources/Json/Spark2.json
+++ b/SampleProject/Resources/Json/Spark2.json
@@ -1,19 +1,19 @@
 {
     "collisionFloor": {
-        "bouncePower": 0.4300000071525574,
+        "bouncePower": 0.0,
         "elevation": 0.0
     },
     "common": {
         "alphaDeltaValue": 0.0,
         "emitInterval": 0.019999999552965164,
-        "emitNum": 20,
+        "emitNum": 29,
         "emitPositionFixed": {
             "x": 6.070000171661377,
             "y": 1.4800000190734863,
             "z": 11.300000190734863
         },
         "emitterLifeTime": 0.0,
-        "particleLifeTime": 7.199999809265137,
+        "particleLifeTime": 3.5999999046325684,
         "scaleDelayTime": 0.0,
         "scaleFixed": {
             "x": 0.4300000071525574,
@@ -27,7 +27,7 @@
         }
     },
     "flags": {
-        "enableCollisionFloor": true,
+        "enableCollisionFloor": false,
         "enableRandomEmit": false,
         "enableRandomRotation": false,
         "enableRandomScale": false,
@@ -36,7 +36,6 @@
     },
     "name": "Spark",
     "physics": {
-        "frictionCoef": 0.6800000071525574,
         "gravity": {
             "x": 0.0,
             "y": -6.460000038146973,
@@ -89,13 +88,13 @@
         },
         "scale": {
             "end": {
-                "x": 0.0,
-                "y": 0.0,
+                "x": 0.10000000149011612,
+                "y": 0.10000000149011612,
                 "z": 1.0
             },
             "start": {
-                "x": 0.10000000149011612,
-                "y": 0.10000000149011612,
+                "x": 0.05000000074505806,
+                "y": 0.05000000074505806,
                 "z": 1.0
             }
         },
@@ -115,12 +114,12 @@
             "end": {
                 "x": 2.4200000762939453,
                 "y": 2.5799999237060547,
-                "z": 1.3200000524520874
+                "z": 2.009999990463257
             },
             "start": {
                 "x": 4.71999979019165,
                 "y": 4.400000095367432,
-                "z": -1.2999999523162842
+                "z": -2.6600000858306885
             }
         }
     },

--- a/SampleProject/imgui.ini
+++ b/SampleProject/imgui.ini
@@ -5,21 +5,21 @@ Collapsed=0
 
 [Window][Log]
 Pos=0,17
-Size=15,22
+Size=17,22
 Collapsed=0
-DockId=0x00000008,0
+DockId=0x00000007,0
 
 [Window][Objects]
 Pos=29,0
 Size=4,22
 Collapsed=0
-DockId=0x00000005,0
+DockId=0x00000009,0
 
 [Window][デバッグ]
 Pos=17,0
 Size=10,22
 Collapsed=0
-DockId=0x0000000D,1
+DockId=0x00000009,1
 
 [Window][SRVManager]
 Pos=726,451
@@ -55,37 +55,37 @@ Collapsed=0
 Pos=24,17
 Size=8,22
 Collapsed=0
-DockId=0x0000000F,0
+DockId=0x0000000D,0
 
 [Window][DebugInfo]
 Pos=26,25
 Size=6,22
 Collapsed=0
-DockId=0x0000000C,0
+DockId=0x00000002,0
 
 [Window][Viewport]
-Pos=0,0
-Size=15,22
+Pos=9,0
+Size=6,22
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][NiUI_DebugInfo]
 Pos=17,0
-Size=10,44
+Size=15,44
 Collapsed=0
-DockId=0x0000000D,0
+DockId=0x00000006,0
 
 [Window][Component data]
 Pos=17,0
 Size=9,27
 Collapsed=0
-DockId=0x0000000D,2
+DockId=0x00000009,2
 
 [Window][EventTimer]
-Pos=17,17
-Size=5,22
+Pos=19,17
+Size=4,22
 Collapsed=0
-DockId=0x0000000A,0
+DockId=0x00000008,0
 
 [Window][Dear ImGui Debug Log]
 Pos=60,60
@@ -100,15 +100,15 @@ DockId=0x00000010,0
 
 [Window][Debug]
 Pos=17,0
-Size=10,22
+Size=15,22
 Collapsed=0
-DockId=0x0000000D,1
+DockId=0x00000006,1
 
 [Window][Components]
-Pos=29,0
-Size=4,22
+Pos=0,0
+Size=7,22
 Collapsed=0
-DockId=0x0000000E,0
+DockId=0x00000004,0
 
 [Table][0x3DFC7327,2]
 Column 0  Weight=1.0000
@@ -658,22 +658,38 @@ Column 1  Weight=1.0000
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
+[Table][0x1C73CA1E,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x1AD45152,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0xC7C67BC7,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x06BF6F0E,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
 [Docking][Data]
-DockSpace         ID=0xD5ACB325 Window=0xA87D555D Pos=0,0 Size=32,32 Split=Y Selected=0x13926F0B
-  DockNode        ID=0x00000001 Parent=0xD5ACB325 SizeRef=1600,708 Split=X Selected=0x13926F0B
-    DockNode      ID=0x00000003 Parent=0x00000001 SizeRef=1064,450 CentralNode=1 Selected=0x13926F0B
-    DockNode      ID=0x00000009 Parent=0x00000001 SizeRef=534,450 Split=X Selected=0x8EDA8100
-      DockNode    ID=0x00000004 Parent=0x00000009 SizeRef=339,597 Split=X Selected=0xC4F72FF0
-        DockNode  ID=0x0000000D Parent=0x00000004 SizeRef=409,710 Selected=0x392A5ADD
-        DockNode  ID=0x0000000E Parent=0x00000004 SizeRef=123,710 Selected=0xFCB30AB3
-      DockNode    ID=0x00000005 Parent=0x00000009 SizeRef=98,597 Selected=0x967E7699
-  DockNode        ID=0x00000002 Parent=0xD5ACB325 SizeRef=1600,241 Split=X Selected=0x64F50EE5
-    DockNode      ID=0x00000006 Parent=0x00000002 SizeRef=1195,271 Split=X Selected=0x64F50EE5
-      DockNode    ID=0x00000008 Parent=0x00000006 SizeRef=920,287 Selected=0x64F50EE5
-      DockNode    ID=0x0000000A Parent=0x00000006 SizeRef=273,287 Selected=0x3A93B30B
-    DockNode      ID=0x00000007 Parent=0x00000002 SizeRef=403,271 Split=Y Selected=0x627D110E
-      DockNode    ID=0x0000000B Parent=0x00000007 SizeRef=320,65 Split=Y Selected=0x8EDA8100
-        DockNode  ID=0x0000000F Parent=0x0000000B SizeRef=358,118 Selected=0x8EDA8100
-        DockNode  ID=0x00000010 Parent=0x0000000B SizeRef=358,121 Selected=0x60B79D0E
-      DockNode    ID=0x0000000C Parent=0x00000007 SizeRef=320,121 Selected=0x627D110E
+DockSpace           ID=0xD5ACB325 Window=0xA87D555D Pos=0,0 Size=32,32 Split=Y Selected=0x13926F0B
+  DockNode          ID=0x0000000A Parent=0xD5ACB325 SizeRef=1600,657 Split=X
+    DockNode        ID=0x0000000C Parent=0x0000000A SizeRef=1189,900 Split=X
+      DockNode      ID=0x00000004 Parent=0x0000000C SizeRef=136,900 Selected=0xFCB30AB3
+      DockNode      ID=0x00000005 Parent=0x0000000C SizeRef=1051,900 Split=Y
+        DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1600,708 Split=X Selected=0x13926F0B
+          DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=1064,450 CentralNode=1 Selected=0x13926F0B
+          DockNode  ID=0x00000009 Parent=0x00000001 SizeRef=534,450 Selected=0x8EDA8100
+        DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=1600,241 Selected=0x64F50EE5
+    DockNode        ID=0x00000006 Parent=0x0000000A SizeRef=409,900 Selected=0x392A5ADD
+  DockNode          ID=0x0000000B Parent=0xD5ACB325 SizeRef=1600,241 Split=X Selected=0x64F50EE5
+    DockNode        ID=0x0000000E Parent=0x0000000B SizeRef=1189,241 Split=X Selected=0x64F50EE5
+      DockNode      ID=0x00000007 Parent=0x0000000E SizeRef=985,241 Selected=0x64F50EE5
+      DockNode      ID=0x00000008 Parent=0x0000000E SizeRef=202,241 Selected=0x3A93B30B
+    DockNode        ID=0x0000000F Parent=0x0000000B SizeRef=409,241 Split=Y Selected=0x60B79D0E
+      DockNode      ID=0x0000000D Parent=0x0000000F SizeRef=409,68 Selected=0x8EDA8100
+      DockNode      ID=0x00000010 Parent=0x0000000F SizeRef=409,171 Selected=0x60B79D0E
 


### PR DESCRIPTION
### EmitterData
- `Type::ParticleEmitter::v3`名前空間を導入し、データ構造を拡張。
- `Common`、`Flags`、`PhysicsData`、`CollisionFloor`、`Data`の各構造体を新たに定義。

### ParticleEmitter
- `EmitParticle`メソッドに衝突半径、摩擦係数、衝突床の処理を追加。

### Particle
- データ更新処理に衝突床の判定を追加し、摩擦の適用処理を改善。

### JSONファイル
- `Rain.json`、`Spark.json`、`Spark2.json`の設定を新しいバージョンに合わせて更新。

### UI
- `imgui.ini`ファイルのレイアウトを変更し、ウィンドウのサイズや位置を調整。