### PR TITLE
feat: ビネットエフェクトの実装を追加

### DIFF
--- a/Engine/Core/DirectX12/DirectX12_Impl.cpp
+++ b/Engine/Core/DirectX12/DirectX12_Impl.cpp
@@ -686,6 +686,8 @@ void DirectX12::ResizeBuffers()
         swapChainResources_[i].state = D3D12_RESOURCE_STATE_PRESENT;
     }
 
+    backBufferIndex_ = swapChain_->GetCurrentBackBufferIndex();
+
     // ビューポート・シザーも更新
     viewport_.Width = static_cast<float>(WinSystem::clientWidth);
     viewport_.Height = static_cast<float>(WinSystem::clientHeight);

--- a/Engine/Core/DirectX12/IPostEffect.h
+++ b/Engine/Core/DirectX12/IPostEffect.h
@@ -35,4 +35,5 @@ private:
     // On resize event
     virtual void    OnResizeBefore() = 0;
     virtual void    OnResizedBuffers() = 0;
+    virtual void    DebugOverlay() = 0;
 };

--- a/Engine/Core/DirectX12/PostEffect.cpp
+++ b/Engine/Core/DirectX12/PostEffect.cpp
@@ -159,6 +159,16 @@ void PostEffect::DebugWindow()
             if (selectedIndex == i) selectedIndex = -1;
             else selectedIndex = i;
         }
+        if (ImGui::BeginPopupContextItem()) // <-- use last item id as popup id
+        {
+            selectedIndex = i;
+            postEffects_[selectedIndex]->DebugOverlay();
+
+            if (ImGui::Button("Close"))
+                ImGui::CloseCurrentPopup();
+            ImGui::EndPopup();
+        }
+        ImGui::SetItemTooltip("Right-click to open setting");
     }
 
     ImGui::Spacing();

--- a/Engine/Effects/PostEffects/Vignette/Vignette.cpp
+++ b/Engine/Effects/PostEffects/Vignette/Vignette.cpp
@@ -1,0 +1,275 @@
+#include "Vignette.h"
+#include <cassert>
+#include <Core/DirectX12/DirectX12.h>
+#include <Core/DirectX12/PostEffect.h>
+#include <Effects/PostEffects/Helper/PostEffectHelper.h>
+#include <Core/DirectX12/SRVManager.h>
+#include <Core/DirectX12/Helper/DX12Helper.h>
+#include <imgui.h>
+
+void PEVignette::Initialize()
+{
+    pDx12_ = DirectX12::GetInstance();
+    device_ = pDx12_->GetDevice();
+    commandList_ = PostEffect::GetInstance()->GetCommandList();
+
+    // レンダーテクスチャの生成
+    Helper::CreateRenderTexture(device_, renderTexture_, rtvHandleCpu_, rtvHeapIndex_);
+    renderTexture_.resource->SetName(L"VignetteRenderTexture");
+
+    // レンダーテクスチャのSRVを生成
+    Helper::CreateSRV(renderTexture_, rtvHandleGpu_, srvHeapIndex_);
+
+    // ルートシグネチャの生成
+    this->CreateRootSignature();
+
+    // パイプラインステートの生成
+    this->CreatePipelineStateObject();
+
+    // 設定用リソースの生成と初期化
+    this->CreateResourceCBuffer();
+}
+
+void PEVignette::Enable(bool _flag)
+{
+    isEnabled_ = _flag;
+}
+
+void PEVignette::SetInputTextureHandle(D3D12_GPU_DESCRIPTOR_HANDLE _gpuHandle)
+{
+    inputGpuHandle_ = _gpuHandle;
+}
+
+bool PEVignette::Enabled() const
+{
+    return isEnabled_;
+}
+
+D3D12_GPU_DESCRIPTOR_HANDLE PEVignette::GetOutputTextureHandle() const
+{
+    return rtvHandleGpu_;
+}
+
+const std::string& PEVignette::GetName() const
+{
+    return name_;
+}
+
+void PEVignette::Apply()
+{
+    commandList_->DrawInstanced(3, 1, 0, 0); // 三角形を1つ描画
+}
+
+void PEVignette::Release()
+{
+}
+
+void PEVignette::Setting()
+{
+    // レンダーテクスチャをレンダーターゲット状態に変更
+    this->ToRenderTargetState();
+
+    // レンダーターゲットを設定 (自分が所有するテクスチャに対して設定)
+    commandList_->OMSetRenderTargets(1, &rtvHandleCpu_, FALSE, nullptr);
+
+    // PSOとルートシグネチャを設定
+    commandList_->SetGraphicsRootSignature(rootSignature_.Get());
+    commandList_->SetPipelineState(pso_.Get());
+
+    // 入力テクスチャのSRVを設定する（自分が所有するテクスチャのSRVではないため注意)
+    commandList_->SetGraphicsRootDescriptorTable(0, inputGpuHandle_);
+
+    commandList_->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+    commandList_->SetGraphicsRootConstantBufferView(1, optionResource_->GetGPUVirtualAddress());
+}
+
+void PEVignette::OnResizeBefore()
+{
+    SRVManager::GetInstance()->Deallocate(srvHeapIndex_);
+    renderTexture_.resource.Reset();
+    renderTexture_.state = D3D12_RESOURCE_STATE_PRESENT;
+}
+
+void PEVignette::OnResizedBuffers()
+{
+    // レンダーテクスチャの生成
+    Helper::CreateRenderTexture(device_, renderTexture_, rtvHandleCpu_, rtvHeapIndex_);
+    // レンダーテクスチャのSRVを生成
+    Helper::CreateSRV(renderTexture_, rtvHandleGpu_, srvHeapIndex_);
+}
+
+void PEVignette::ToShaderResourceState()
+{
+    // レンダーテクスチャをシェーダーリソース状態に変更
+    DX12Helper::ChangeStateResource(
+        commandList_,
+        renderTexture_,
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
+    );
+}
+
+void PEVignette::DebugOverlay()
+{
+    #ifdef _DEBUG
+
+    ImGui::DragFloat("Scale", &pOption_->scale, 0.01f, FLT_MIN);
+    ImGui::DragFloat("Power", &pOption_->power, 0.01f, FLT_MIN);
+
+    #endif //_DEBUG
+}
+
+void PEVignette::CreateRootSignature()
+{
+    D3D12_DESCRIPTOR_RANGE descriptorRange[1] = {};
+    descriptorRange[0].BaseShaderRegister = 0; // 0から始まる
+    descriptorRange[0].NumDescriptors = 1; // 数は1つ
+    descriptorRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV; // SRVを使う
+    descriptorRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND; // Offsetを自動計算
+
+    /// RootSignature作成
+    D3D12_ROOT_SIGNATURE_DESC descriptionRootSignature{};
+    descriptionRootSignature.Flags =
+        D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+
+    // RootParameter作成。複数設定できるので配列
+    D3D12_ROOT_PARAMETER rootParameters[2] = {};
+    rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;       // DescriptorTableを使う
+    rootParameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;                 // PixelShaderで使う
+    rootParameters[0].DescriptorTable.pDescriptorRanges = descriptorRange;              // Tableの中身の配列を指定
+    rootParameters[0].DescriptorTable.NumDescriptorRanges = _countof(descriptorRange);  // Tableで利用する数
+
+    rootParameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+    rootParameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+    rootParameters[1].Descriptor.ShaderRegister = 0;
+
+
+    descriptionRootSignature.pParameters = rootParameters;                              // ルートパラメータ配列へのポインタ
+    descriptionRootSignature.NumParameters = _countof(rootParameters);                  // 配列の長さ
+
+    D3D12_STATIC_SAMPLER_DESC staticSamplers[1] = {};
+    staticSamplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;              // 異方性フィルタリング
+    staticSamplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    staticSamplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    staticSamplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    staticSamplers[0].MipLODBias = 0.0f;                                    // ミップマップのオフセット
+    staticSamplers[0].MaxAnisotropy = 16;                                   // 最大異方性
+    staticSamplers[0].ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;         // 比較なし
+    staticSamplers[0].BorderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE; // ボーダーカラー
+    staticSamplers[0].MinLOD = 0.0f;                                        // 最小ミップレベル
+    staticSamplers[0].MaxLOD = D3D12_FLOAT32_MAX;                           // 最大ミップレベル
+    staticSamplers[0].ShaderRegister = 0;                                   // サンプラーのレジスタ番号
+    staticSamplers[0].RegisterSpace = 0;                                    // レジスタスペース
+    staticSamplers[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;     // ピクセルシェーダーで使用
+
+    descriptionRootSignature.pStaticSamplers = staticSamplers;
+    descriptionRootSignature.NumStaticSamplers = _countof(staticSamplers);
+
+    // シリアライズしてバイナリにする
+    Microsoft::WRL::ComPtr<ID3DBlob> signatureBlob = nullptr;
+    Microsoft::WRL::ComPtr<ID3DBlob> errorBlob = nullptr;
+    HRESULT hr = D3D12SerializeRootSignature(&descriptionRootSignature, D3D_ROOT_SIGNATURE_VERSION_1, &signatureBlob, &errorBlob);
+    if (FAILED(hr))
+    {
+        Logger::GetInstance()->LogError(
+            "Object3dSystem",
+            "CreateRootSignature",
+            reinterpret_cast<char*>(errorBlob->GetBufferPointer())
+        );
+
+        assert(false);
+    }
+    // バイナリをもとに生成
+    hr = device_->CreateRootSignature(0, signatureBlob->GetBufferPointer(), signatureBlob->GetBufferSize(), IID_PPV_ARGS(&rootSignature_));
+    assert(SUCCEEDED(hr));
+}
+
+void PEVignette::CreatePipelineStateObject()
+{
+    IDxcUtils* dxcUtils = pDx12_->GetDxcUtils();
+    IDxcCompiler3* dxcCompiler = pDx12_->GetDxcCompiler();
+    IDxcIncludeHandler* includeHandler = pDx12_->GetIncludeHandler();
+
+    D3D12_INPUT_LAYOUT_DESC inputLayoutDesc{};
+    inputLayoutDesc.pInputElementDescs = nullptr;
+    inputLayoutDesc.NumElements = 0;
+
+    /// BlendStateの設定
+    D3D12_BLEND_DESC blendDesc{};
+    blendDesc.RenderTarget[0].BlendEnable = TRUE;
+    blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
+    blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
+    blendDesc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+    blendDesc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
+    blendDesc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
+    blendDesc.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
+    blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+
+
+    /// RasterizerStateの設定
+    D3D12_RASTERIZER_DESC rasterizerDesc{};
+    rasterizerDesc.CullMode = D3D12_CULL_MODE_NONE;
+    rasterizerDesc.FillMode = D3D12_FILL_MODE_SOLID;
+    rasterizerDesc.MultisampleEnable = TRUE;  // アンチエイリアス有効化
+    rasterizerDesc.AntialiasedLineEnable = TRUE;  // ラインのアンチエイリアス有効化
+
+    /// ShaderをCompileする
+    vertexShaderBlob_ = DX12Helper::CompileShader(kVertexShaderPath, L"vs_6_0", dxcUtils, dxcCompiler, includeHandler);
+    assert(vertexShaderBlob_ != nullptr);
+
+    pixelShaderBlob_ = DX12Helper::CompileShader(kPixelShaderPath, L"ps_6_0", dxcUtils, dxcCompiler, includeHandler);
+    assert(pixelShaderBlob_ != nullptr);
+
+    /// PSOを生成する
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicsPipelineStateDesc{};
+    graphicsPipelineStateDesc.pRootSignature = rootSignature_.Get();    // RootSignature
+    graphicsPipelineStateDesc.InputLayout = inputLayoutDesc;    // InputLayout
+    graphicsPipelineStateDesc.VS = { vertexShaderBlob_.Get()->GetBufferPointer(), vertexShaderBlob_.Get()->GetBufferSize() };
+    graphicsPipelineStateDesc.PS = { pixelShaderBlob_.Get()->GetBufferPointer(), pixelShaderBlob_.Get()->GetBufferSize() };
+    graphicsPipelineStateDesc.BlendState = blendDesc;            // BlendState
+    graphicsPipelineStateDesc.RasterizerState = rasterizerDesc;    // RasterizerState
+    // 書き込むRTVの情報
+    graphicsPipelineStateDesc.NumRenderTargets = 1;
+    graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+    // 利用するトポロジ（形状）のタイプ。三角形
+    graphicsPipelineStateDesc.PrimitiveTopologyType =
+        D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    // どのように画面に色を打ち込むかの設定（気にしなくて良い）
+    graphicsPipelineStateDesc.SampleDesc.Count = 1;
+    graphicsPipelineStateDesc.SampleMask = D3D12_DEFAULT_SAMPLE_MASK;
+    // DepthStencilの設定
+    graphicsPipelineStateDesc.DepthStencilState = {};
+    graphicsPipelineStateDesc.DSVFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+    // 実際に生成
+    HRESULT hr = device_->CreateGraphicsPipelineState(&graphicsPipelineStateDesc, IID_PPV_ARGS(&pso_));
+    if (FAILED(hr))
+    {
+        Logger::GetInstance()->LogError(
+            "PostEffect",
+            "CreatePipelineState",
+            "Failed to create pipeline state"
+        );
+        assert(false);
+    }
+
+    return;
+}
+
+void PEVignette::ToRenderTargetState()
+{
+    // レンダーテクスチャをレンダーターゲット状態に変更
+    DX12Helper::ChangeStateResource(
+        commandList_,
+        renderTexture_,
+        D3D12_RESOURCE_STATE_RENDER_TARGET
+    );
+}
+
+void PEVignette::CreateResourceCBuffer()
+{
+    optionResource_ = DX12Helper::CreateBufferResource(device_, sizeof(VignetteOption));
+    optionResource_->Map(0, nullptr, reinterpret_cast<void**>(&pOption_));
+
+    pOption_->scale = 16.0f;
+    pOption_->power = 0.8f;
+}

--- a/Engine/Effects/PostEffects/Vignette/Vignette.h
+++ b/Engine/Effects/PostEffects/Vignette/Vignette.h
@@ -7,17 +7,28 @@
 #include <Core/DirectX12/DirectX12.h>
 #include <Core/DirectX12/ResourceStateTracker/ResourceStateTracker.h>
 
-/// <グレースケール>
+/// <ビネット>
 /// - PEはPost Effectの略
 /// - ApplyメソッドとSettingメソッドはPostEffectクラスで実行する
-class PEGrayscale : public IPostEffect
+class PEVignette : public IPostEffect
 {
+public:
+    struct VignetteOption
+    {
+        float scale;
+        float power;
+    };
+
 public:
     void    Initialize() override;
     void    Release() override;
 
     void    Enable(bool _flag) override;
     bool    Enabled() const override;
+
+    // Setter (Additional)
+    void    SetScale(float _scale) { pOption_->scale = _scale; }
+    void    SetPower(float _power) { pOption_->power = _power; }
 
 private:
     // PostEffectクラスがアクセスする
@@ -26,7 +37,7 @@ private:
     void    OnResizeBefore() override;
     void    OnResizedBuffers() override;
     void    ToShaderResourceState() override;
-    void    DebugOverlay() override {};
+    void    DebugOverlay() override;
 
     // Setters
     void    SetInputTextureHandle(D3D12_GPU_DESCRIPTOR_HANDLE _gpuHandle) override;
@@ -41,7 +52,7 @@ private:
     DirectX12*                                          pDx12_                  = nullptr;
 
     bool                                                isEnabled_              = true;
-    const std::string                                   name_                   = "Grayscale";
+    const std::string                                   name_                   = "Vignette";
     ResourceStateTracker                                renderTexture_          = {};
     Microsoft::WRL::ComPtr<IDxcBlob>                    vertexShaderBlob_       = nullptr;
     Microsoft::WRL::ComPtr<IDxcBlob>                    pixelShaderBlob_        = nullptr;
@@ -52,11 +63,17 @@ private:
     D3D12_GPU_DESCRIPTOR_HANDLE                         inputGpuHandle_         = {};
     uint32_t                                            rtvHeapIndex_           = 0;
     uint32_t                                            srvHeapIndex_           = 0;
-    const std::wstring                                  kVertexShaderPath       = L"EngineResources/Shaders/Grayscale.VS.hlsl";
-    const std::wstring                                  kPixelShaderPath        = L"EngineResources/Shaders/Grayscale.PS.hlsl";
+    const std::wstring                                  kVertexShaderPath       = L"EngineResources/Shaders/Vignette.VS.hlsl";
+    const std::wstring                                  kPixelShaderPath        = L"EngineResources/Shaders/Vignette.PS.hlsl";
+
+    // Constant buffer view
+    Microsoft::WRL::ComPtr<ID3D12Resource>      optionResource_     = nullptr;
+    VignetteOption*                             pOption_            = nullptr;
+
 
     // Internal functions
     void    CreateRootSignature();
     void    CreatePipelineStateObject();
     void    ToRenderTargetState();
+    void    CreateResourceCBuffer();
 };

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -210,6 +210,7 @@
     <ClCompile Include="DebugTools\Logger\Logger.cpp" />
     <ClCompile Include="Effects\PostEffects\Grayscale\Grayscale.cpp" />
     <ClCompile Include="Effects\PostEffects\Helper\PostEffectHelper.cpp" />
+    <ClCompile Include="Effects\PostEffects\Vignette\Vignette.cpp" />
     <ClCompile Include="Externals\Timer\Timer.cpp" />
     <ClCompile Include="Features\Audio\Audio.cpp" />
     <ClCompile Include="Features\Audio\AudioManager.cpp" />
@@ -285,6 +286,7 @@
     <ClInclude Include="DebugTools\ReakChecker.h" />
     <ClInclude Include="Effects\PostEffects\Grayscale\Grayscale.h" />
     <ClInclude Include="Effects\PostEffects\Helper\PostEffectHelper.h" />
+    <ClInclude Include="Effects\PostEffects\Vignette\Vignette.h" />
     <ClInclude Include="Externals\Timer\Timer.h" />
     <ClInclude Include="Features\Audio\Audio.h" />
     <ClInclude Include="Features\Audio\AudioManager.h" />
@@ -454,6 +456,16 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </FxCompile>
     <FxCompile Include="EngineResources\Shaders\Sprite.VS.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_ASAN|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
+    <FxCompile Include="EngineResources\Shaders\Vignette.PS.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_ASAN|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
+    <FxCompile Include="EngineResources\Shaders\Vignette.VS.hlsl">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_ASAN|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>

--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -250,6 +250,9 @@
     <Filter Include="Effect\PostEffect\Helper">
       <UniqueIdentifier>{2946dbcb-0581-4d0b-af8b-3987d55efe5e}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Effect\PostEffect\Vignette">
+      <UniqueIdentifier>{b83890bf-4f67-4ef7-a098-3c2f12d2fc01}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DebugTools\DebugManager\DebugManager.cpp">
@@ -455,6 +458,9 @@
     </ClCompile>
     <ClCompile Include="Effects\PostEffects\Grayscale\Grayscale.cpp">
       <Filter>Effect\PostEffect\Grayscale</Filter>
+    </ClCompile>
+    <ClCompile Include="Effects\PostEffects\Vignette\Vignette.cpp">
+      <Filter>Effect\PostEffect\Vignette</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -716,6 +722,9 @@
     <ClInclude Include="Effects\PostEffects\Helper\PostEffectHelper.h">
       <Filter>Effect\PostEffect\Helper</Filter>
     </ClInclude>
+    <ClInclude Include="Effects\PostEffects\Vignette\Vignette.h">
+      <Filter>Effect\PostEffect\Vignette</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />
@@ -777,6 +786,12 @@
       <Filter>HLSL</Filter>
     </FxCompile>
     <FxCompile Include="EngineResources\Shaders\Grayscale.VS.hlsl">
+      <Filter>HLSL</Filter>
+    </FxCompile>
+    <FxCompile Include="EngineResources\Shaders\Vignette.PS.hlsl">
+      <Filter>HLSL</Filter>
+    </FxCompile>
+    <FxCompile Include="EngineResources\Shaders\Vignette.VS.hlsl">
       <Filter>HLSL</Filter>
     </FxCompile>
   </ItemGroup>

--- a/Engine/EngineResources/Shaders/Vignette.PS.hlsl
+++ b/Engine/EngineResources/Shaders/Vignette.PS.hlsl
@@ -1,0 +1,38 @@
+#include "Fullscreen.hlsli"
+
+Texture2D<float4> gTexture : register(t0);
+SamplerState gSampler : register(s0);
+
+struct PixelShaderOutput
+{
+    float4 color : SV_TARGET0;
+};
+
+struct VignetteOption
+{
+    float scale;
+    float power;
+};
+
+ConstantBuffer<VignetteOption> gOption : register(b0);
+
+PixelShaderOutput main(VertexShaderOutput input)
+{
+    PixelShaderOutput output;
+    output.color = gTexture.Sample(gSampler, input.texcoord);
+    
+    // 周囲を0に、中心になるほど明るくなるようにする
+    float2 correct = input.texcoord * (1.0f - input.texcoord.yx);
+
+    // 中心の最大値が暗すぎるためScaleで調整する (cbv)
+    float vignette = correct.x * correct.y * gOption.scale;
+    
+    // サチュレーションで超えないようにしながら、いい感じに
+    vignette = saturate(pow(vignette, gOption.power));
+    
+    // 係数として乗算
+    output.color.rgb *= vignette;
+    output.color.a = 1.0f;
+
+    return output;
+}

--- a/Engine/EngineResources/Shaders/Vignette.VS.hlsl
+++ b/Engine/EngineResources/Shaders/Vignette.VS.hlsl
@@ -1,0 +1,24 @@
+#include "Fullscreen.hlsli"
+
+static const uint kNumVertex = 3;
+static const float4 kPositions[kNumVertex] =
+{
+    { -1.0f, 1.0f, 0.0f, 1.0f },
+    { 3.0f, 1.0f, 0.0f, 1.0f },
+    { -1.0f, -3.0f, 0.0f, 1.0f }
+};
+static const float2 kTexCoords[kNumVertex] =
+{
+    { 0.0f, 0.0f },
+    { 2.0f, 0.0f },
+    { 0.0f, 2.0f }
+};
+
+VertexShaderOutput main(uint vertexId : SV_VertexID)
+{
+    VertexShaderOutput output;
+    output.position = kPositions[vertexId];
+    output.texcoord = kTexCoords[vertexId];
+
+    return output;
+}

--- a/Engine/Features/Object3d/Object3dSystem.cpp
+++ b/Engine/Features/Object3d/Object3dSystem.cpp
@@ -255,7 +255,7 @@ void Object3dSystem::CreateMainPipelineState()
     pixelShaderBlob_ = DX12Helper::CompileShader(kPixelShaderPath, L"ps_6_0", dxcUtils, dxcCompiler, includeHandler);
     assert(pixelShaderBlob_ != nullptr);
 
-    // DespStencilResource
+    // DepthStencilResource
     Microsoft::WRL::ComPtr<ID3D12Resource> depthStencilResource = DX12Helper::CreateDepthStencilTextureResource(device, clientWidth, clientHeight);
     // DSV用のヒープでディスクリプタの数は1。DSVはShader内で触るものではないため、ShaderVisibleはfalse
     Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> dsvDescriptorHeap = DX12Helper::CreateDescriptorHeap(device, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, 1, false);

--- a/SampleProject/EngineResources/Shaders/Vignette.PS.hlsl
+++ b/SampleProject/EngineResources/Shaders/Vignette.PS.hlsl
@@ -1,0 +1,38 @@
+#include "Fullscreen.hlsli"
+
+Texture2D<float4> gTexture : register(t0);
+SamplerState gSampler : register(s0);
+
+struct PixelShaderOutput
+{
+    float4 color : SV_TARGET0;
+};
+
+struct VignetteOption
+{
+    float scale;
+    float power;
+};
+
+ConstantBuffer<VignetteOption> gOption : register(b0);
+
+PixelShaderOutput main(VertexShaderOutput input)
+{
+    PixelShaderOutput output;
+    output.color = gTexture.Sample(gSampler, input.texcoord);
+    
+    // 周囲を0に、中心になるほど明るくなるようにする
+    float2 correct = input.texcoord * (1.0f - input.texcoord.yx);
+
+    // 中心の最大値が暗すぎるためScaleで調整する (cbv)
+    float vignette = correct.x * correct.y * gOption.scale;
+    
+    // サチュレーションで超えないようにしながら、いい感じに
+    vignette = saturate(pow(vignette, gOption.power));
+    
+    // 係数として乗算
+    output.color.rgb *= vignette;
+    output.color.a = 1.0f;
+
+    return output;
+}

--- a/SampleProject/EngineResources/Shaders/Vignette.VS.hlsl
+++ b/SampleProject/EngineResources/Shaders/Vignette.VS.hlsl
@@ -1,0 +1,24 @@
+#include "Fullscreen.hlsli"
+
+static const uint kNumVertex = 3;
+static const float4 kPositions[kNumVertex] =
+{
+    { -1.0f, 1.0f, 0.0f, 1.0f },
+    { 3.0f, 1.0f, 0.0f, 1.0f },
+    { -1.0f, -3.0f, 0.0f, 1.0f }
+};
+static const float2 kTexCoords[kNumVertex] =
+{
+    { 0.0f, 0.0f },
+    { 2.0f, 0.0f },
+    { 0.0f, 2.0f }
+};
+
+VertexShaderOutput main(uint vertexId : SV_VertexID)
+{
+    VertexShaderOutput output;
+    output.position = kPositions[vertexId];
+    output.texcoord = kTexCoords[vertexId];
+
+    return output;
+}

--- a/SampleProject/Scene/CG4Task1/CG4Task1.cpp
+++ b/SampleProject/Scene/CG4Task1/CG4Task1.cpp
@@ -55,8 +55,13 @@ void CG4Task1::Initialize()
     pEmitter_Test_->SetEnableBillboard(true);
 
     pPEGrayscale_ = std::make_unique<PEGrayscale>();
-    PostEffect::GetInstance()->AddPostEffect(pPEGrayscale_.get());
     pPEGrayscale_->Initialize();
+
+    pPEVignette_ = std::make_unique<PEVignette>();
+    pPEVignette_->Initialize();
+
+    PostEffect::GetInstance()->AddPostEffect(pPEGrayscale_.get())
+        .AddPostEffect(pPEVignette_.get());
 }
 
 void CG4Task1::Finalize()

--- a/SampleProject/Scene/CG4Task1/CG4Task1.h
+++ b/SampleProject/Scene/CG4Task1/CG4Task1.h
@@ -5,6 +5,7 @@
 #include <Features/Object3d/Object3d.h>
 #include <Features/GameEye/GameEye.h>
 #include <Effects/PostEffects/Grayscale/Grayscale.h>
+#include <Effects/PostEffects/Vignette/Vignette.h>
 
 #include <memory>
 #include <Features/Particle/Emitter/ParticleEmitter.h>
@@ -36,6 +37,7 @@ private:
     std::unique_ptr<ParticleEmitter>    pEmitter_Spark_     = nullptr;
     std::unique_ptr<ParticleEmitter>    pEmitter_Test_      = nullptr;
     std::unique_ptr<PEGrayscale>        pPEGrayscale_       = nullptr;
+    std::unique_ptr<PEVignette>         pPEVignette_        = nullptr;
 
     // Pointers
     Input*  pInput_     = nullptr;


### PR DESCRIPTION
* `IPostEffect.h`
  - `DebugOverlay` メソッドを追加し、デバッグオーバーレイを表示するための純粋仮想関数を定義。

* `PostEffect.cpp`
  - `DebugWindow` メソッドに右クリックでポップアップメニューを開く機能を追加。
  - ポップアップメニューにデバッグオーバーレイを表示するボタンを追加。

* `Grayscale.h`
  - `DebugOverlay` メソッドを追加し、空の実装を提供。

* `CG4Task1.cpp`
  - `Initialize` メソッドで `PEVignette` のインスタンスを作成し、ポストエフェクトのリストに追加。

* `CG4Task1.h`
  - `PEVignette` のヘッダーを追加し、`pPEVignette_` メンバー変数を追加。

* `Vignette.cpp` と `Vignette.h`
  - ビネットエフェクトの初期化、リソース管理、シェーダー設定、デバッグオーバーレイ表示の実装を追加。

* `Vignette.PS.hlsl` と `Vignette.VS.hlsl`
  - ビネットエフェクトのピクセルシェーダーとバーテックスシェーダーを実装。

* その他
  - `Object3dSystem.cpp` の `CreateMainPipelineState` メソッド内で `DepthStencilResource` のコメントを修正。