### PR TITLE
feat: PEVignetteに色編集機能とブレンディング追加

### DIFF
--- a/Engine/Effects/PostEffects/Vignette/Vignette.cpp
+++ b/Engine/Effects/PostEffects/Vignette/Vignette.cpp
@@ -112,9 +112,10 @@ void PEVignette::ToShaderResourceState()
 void PEVignette::DebugOverlay()
 {
     #ifdef _DEBUG
-
     ImGui::DragFloat("Scale", &pOption_->scale, 0.01f, FLT_MIN);
     ImGui::DragFloat("Power", &pOption_->power, 0.01f, FLT_MIN);
+    ImGui::ColorEdit3("Power", &pOption_->color.x);
+    ImGui::Checkbox("Multiply blending", reinterpret_cast<bool*>(&pOption_->enableMultiply));
 
     #endif //_DEBUG
 }
@@ -272,4 +273,5 @@ void PEVignette::CreateResourceCBuffer()
 
     pOption_->scale = 16.0f;
     pOption_->power = 0.8f;
+    pOption_->color = { 0.0f, 0.0f, 0.0f };
 }

--- a/Engine/Effects/PostEffects/Vignette/Vignette.h
+++ b/Engine/Effects/PostEffects/Vignette/Vignette.h
@@ -6,6 +6,8 @@
 #include <dxcapi.h>
 #include <Core/DirectX12/DirectX12.h>
 #include <Core/DirectX12/ResourceStateTracker/ResourceStateTracker.h>
+#include <Vector4.h>
+#include <Vector3.h>
 
 /// <ビネット>
 /// - PEはPost Effectの略
@@ -15,8 +17,11 @@ class PEVignette : public IPostEffect
 public:
     struct VignetteOption
     {
+        Vector3 color;
         float scale;
         float power;
+        int enableMultiply;
+        Vector3 padding;
     };
 
 public:

--- a/Engine/EngineResources/Shaders/Vignette.PS.hlsl
+++ b/Engine/EngineResources/Shaders/Vignette.PS.hlsl
@@ -10,8 +10,12 @@ struct PixelShaderOutput
 
 struct VignetteOption
 {
+    float3 color;
     float scale;
     float power;
+    int enableMultiply;
+    
+    float3 padding;
 };
 
 ConstantBuffer<VignetteOption> gOption : register(b0);
@@ -31,7 +35,11 @@ PixelShaderOutput main(VertexShaderOutput input)
     vignette = saturate(pow(vignette, gOption.power));
     
     // 係数として乗算
-    output.color.rgb *= vignette;
+    float3 color_blend_alpha = lerp(gOption.color.rgb, output.color.rgb, vignette);
+    float3 color_blend_multiply = output.color.rgb * lerp(gOption.color.rgb, float3(1,1,1), vignette);
+    
+    output.color.rgb = lerp(color_blend_alpha, color_blend_multiply, float(gOption.enableMultiply));
+    
     output.color.a = 1.0f;
 
     return output;

--- a/Engine/Features/Particle/ParticleSystem.h
+++ b/Engine/Features/Particle/ParticleSystem.h
@@ -56,7 +56,6 @@ private: /// メンバ変数
     static constexpr wchar_t kPixelShaderPath[] = L"EngineResources/Shaders/Particle.PS.hlsl";
     Microsoft::WRL::ComPtr<ID3D12RootSignature> rootSignature_ = nullptr;
     Microsoft::WRL::ComPtr<ID3D12PipelineState> graphicsPipelineState_ = nullptr;
-    GameEye* pGlobalEye_ = nullptr;
     D3D12_CPU_DESCRIPTOR_HANDLE* rtvHandle_ = nullptr;
 
     std::list<CommandListData> commandListDatas_;

--- a/Engine/Framework/NimaFramework.cpp
+++ b/Engine/Framework/NimaFramework.cpp
@@ -148,6 +148,15 @@ void NimaFramework::Initialize()
     /// ポストエフェクト
     pPostEffect_->Initialize();
 
+    pPEGrayscale_ = std::make_unique<PEGrayscale>();
+    pPEGrayscale_->Initialize();
+
+    pPEVignette_ = std::make_unique<PEVignette>();
+    pPEVignette_->Initialize();
+
+    PostEffect::GetInstance()->AddPostEffect(pPEGrayscale_.get())
+        .AddPostEffect(pPEVignette_.get());
+
     /// コマンドリストを追加
     pDirectX_->AddCommandList(pObject3dSystem_->GetCommandList());
     pDirectX_->AddCommandList(pParticleSystem_->GetCommandList());

--- a/Engine/Framework/NimaFramework.h
+++ b/Engine/Framework/NimaFramework.h
@@ -24,6 +24,8 @@
 #include <Features/NiGui/NiGuiDrawer.h>
 #include <Features/NiGui/NiGuiDebug.h>
 #include <DebugTools/EventTimer/EventTimer.h>
+#include <Effects/PostEffects/Grayscale/Grayscale.h>
+#include <Effects/PostEffects/Vignette/Vignette.h>
 
 #include <memory> /// std::unique_ptr
 #include <Core/DirectX12/PostEffect.h>
@@ -49,7 +51,8 @@ public:
     void                            PostProcess();
 
 
-protected: /// システムクラスのインスタンス
+protected: 
+    /// システムクラスのインスタンス
     std::unique_ptr<ISceneFactory>  pSceneFactory_              = nullptr;
     std::unique_ptr<Viewport>       pViewport_                  = nullptr;
     std::unique_ptr<NiGuiDrawer>    pDrawer_                    = nullptr;
@@ -59,8 +62,7 @@ protected: /// システムクラスのインスタンス
     std::unique_ptr<ImGuiManager>   pImGuiManager_              = nullptr;
     #endif // _DEBUG
 
-
-protected: /// 他クラスのインスタンス
+    /// 他クラスのインスタンス
     ConfigManager*                  pConfigManager_             = nullptr;
     Logger*                         pLogger_                    = nullptr;
     DirectX12*                      pDirectX_                   = nullptr;
@@ -81,6 +83,10 @@ protected: /// 他クラスのインスタンス
     AudioManager*                   pAudioManager_              = nullptr;
     EventTimer*                     pEventTimer_                = nullptr;
     PostEffect*                     pPostEffect_                = nullptr;
+
+    // ポストエフェクト
+    std::unique_ptr<PEGrayscale>    pPEGrayscale_       = nullptr;
+    std::unique_ptr<PEVignette>     pPEVignette_        = nullptr;
 
 
 protected:

--- a/SampleProject/EngineResources/Shaders/Vignette.PS.hlsl
+++ b/SampleProject/EngineResources/Shaders/Vignette.PS.hlsl
@@ -10,8 +10,12 @@ struct PixelShaderOutput
 
 struct VignetteOption
 {
+    float3 color;
     float scale;
     float power;
+    int enableMultiply;
+    
+    float3 padding;
 };
 
 ConstantBuffer<VignetteOption> gOption : register(b0);
@@ -31,7 +35,11 @@ PixelShaderOutput main(VertexShaderOutput input)
     vignette = saturate(pow(vignette, gOption.power));
     
     // 係数として乗算
-    output.color.rgb *= vignette;
+    float3 color_blend_alpha = lerp(gOption.color.rgb, output.color.rgb, vignette);
+    float3 color_blend_multiply = output.color.rgb * lerp(gOption.color.rgb, float3(1,1,1), vignette);
+    
+    output.color.rgb = lerp(color_blend_alpha, color_blend_multiply, float(gOption.enableMultiply));
+    
     output.color.a = 1.0f;
 
     return output;

--- a/SampleProject/SampleProject.vcxproj
+++ b/SampleProject/SampleProject.vcxproj
@@ -101,7 +101,8 @@
     </Link>
     <PostBuildEvent>
       <Command>copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxcompiler.dll" "$(TargetDir)dxcompiler.dll"
-copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dxil.dll"</Command>
+copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dxil.dll"
+xcopy "../Engine/EngineResources" "./EngineResources" /I /Y /E</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ASAN|x64'">

--- a/SampleProject/Scene/CG4Task1/CG4Task1.cpp
+++ b/SampleProject/Scene/CG4Task1/CG4Task1.cpp
@@ -53,15 +53,6 @@ void CG4Task1::Initialize()
     pEmitter_Test_ = std::make_unique<ParticleEmitter>();
     pEmitter_Test_->Initialize("Particle/ParticleSpark.obj", "spark.png");
     pEmitter_Test_->SetEnableBillboard(true);
-
-    pPEGrayscale_ = std::make_unique<PEGrayscale>();
-    pPEGrayscale_->Initialize();
-
-    pPEVignette_ = std::make_unique<PEVignette>();
-    pPEVignette_->Initialize();
-
-    PostEffect::GetInstance()->AddPostEffect(pPEGrayscale_.get())
-        .AddPostEffect(pPEVignette_.get());
 }
 
 void CG4Task1::Finalize()

--- a/SampleProject/Scene/CG4Task1/CG4Task1.h
+++ b/SampleProject/Scene/CG4Task1/CG4Task1.h
@@ -4,8 +4,7 @@
 #include <Interfaces/IScene.h>
 #include <Features/Object3d/Object3d.h>
 #include <Features/GameEye/GameEye.h>
-#include <Effects/PostEffects/Grayscale/Grayscale.h>
-#include <Effects/PostEffects/Vignette/Vignette.h>
+
 
 #include <memory>
 #include <Features/Particle/Emitter/ParticleEmitter.h>
@@ -36,8 +35,6 @@ private:
     std::unique_ptr<ParticleEmitter>    pEmitter_Snow_      = nullptr;
     std::unique_ptr<ParticleEmitter>    pEmitter_Spark_     = nullptr;
     std::unique_ptr<ParticleEmitter>    pEmitter_Test_      = nullptr;
-    std::unique_ptr<PEGrayscale>        pPEGrayscale_       = nullptr;
-    std::unique_ptr<PEVignette>         pPEVignette_        = nullptr;
 
     // Pointers
     Input*  pInput_     = nullptr;


### PR DESCRIPTION
* `PEVignette::DebugOverlay` メソッドに、色を編集するための `ImGui::ColorEdit3` と、乗算ブレンディングを有効にするための `ImGui::Checkbox` を追加。
* `PEVignette::CreateResourceCBuffer` メソッドで、`pOption_->color` を初期化。
* `Vignette.h` に `Vector3` と `Vector4` のインクルードを追加し、`VignetteOption` 構造体に `color` と `enableMultiply` メンバーを追加。
* `Vignette.PS.hlsl` の `VignetteOption` 構造体に `color` と `enableMultiply` メンバーを追加し、ピクセルシェーダーの出力に色のブレンド処理を追加。
* `NimaFramework.cpp` の `Initialize` メソッドで、`PEGrayscale` と `PEVignette` のインスタンスを作成し、初期化してポストエフェクトに追加。
* `NimaFramework.h` に `PEGrayscale` と `PEVignette` のユニークポインタを追加し、関連するインクルードを追加。
* `CG4Task1.cpp` の `Initialize` メソッドから `PEGrayscale` と `PEVignette` のインスタンス作成と初期化を削除。
* `CG4Task1.h` から `PEGrayscale` と `PEVignette` のインクルードを削除し、関連するユニークポインタも削除。

バイナリファイルやJSONの変更はありません。