### PR TITLE
change: SceneObjectsとModelHelperの改善

### DIFF
--- a/Engine/Features/LevelLoader/SceneObjects.cpp
+++ b/Engine/Features/LevelLoader/SceneObjects.cpp
@@ -66,7 +66,7 @@ std::string SceneObjects::GetName() const
     return levelData_.name.empty() ? "Unnamed Scene" : levelData_.name;
 }
 
-#ifdef DEBUG
+#ifdef _DEBUG
 void ImGuiTextTransform(const EulerTransform& _tf)
 {
     #ifdef _DEBUG
@@ -78,7 +78,7 @@ void ImGuiTextTransform(const EulerTransform& _tf)
     _tf;
     #endif // _DEBUG
 }
-#endif // DEBUG
+#endif // _DEBUG
 
 void SceneObjects::ImGui()
 {

--- a/Engine/Features/Model/Helper/ModelHelper.cpp
+++ b/Engine/Features/Model/Helper/ModelHelper.cpp
@@ -188,3 +188,17 @@ void Helper::Model::DispatchModel(IModel* _pModel)
 
     ptr->DispatchSkinning();
 }
+
+std::unique_ptr<ModelStorage> Helper::Model::CreateStorage()
+{
+    return std::make_unique<ModelStorage>();
+}
+
+std::unique_ptr<ModelManager> Helper::Model::CreateManager(IModelLoader* _pLoader, ModelStorage* _pStorage)
+{
+    auto pModelManager = std::make_unique<ModelManager>();
+    pModelManager->Initialize();
+    pModelManager->SetModelLoader(_pLoader);
+    pModelManager->SetModelStorage(_pStorage);
+    return pModelManager;
+}

--- a/Engine/Features/Model/Helper/ModelHelper.h
+++ b/Engine/Features/Model/Helper/ModelHelper.h
@@ -2,6 +2,11 @@
 
 #include <string>
 #include <Features/Model/IModel.h>
+#include <Features/Model/ModelManager.h>
+#include <memory>
+#include <Core/DirectX12/DirectX12.h>
+#include <Features/Model/Loader/Assimp/ModelLoaderAssimp.h>
+#include <Features/Model/ModelStorage.h>
 
 struct ModelData;
 struct MaterialData;
@@ -11,4 +16,18 @@ namespace Helper::Model
     ModelData LoadObjFile(const std::string& _directoryPath, const std::string& _filename, const std::string& _texturePath = {});
     MaterialData LoadMaterialTemplateFile(const std::string& _directoryPath, const std::string& _filename, const std::string& _texturePath = {});
     void DispatchModel(IModel* _pModel);
+
+    template <typename _Loader>
+    std::unique_ptr<_Loader> CreateLoader(DirectX12* _pDx12)
+    {
+        // IModelLoaderを継承しているかどうか
+        static_assert(std::is_base_of<IModelLoader, _Loader>::value, "Loader must inherit from IModelLoader");
+
+        auto pLoader = std::make_unique<_Loader>();
+        pLoader->SetDirectX12(_pDx12);
+        pLoader->Initialize();
+        return pLoader;
+    }
+    std::unique_ptr<ModelStorage> CreateStorage();
+    std::unique_ptr<ModelManager> CreateManager(IModelLoader* _pLoader, ModelStorage* _pStorage);
 }

--- a/SampleProject/SampleProgram/SampleProgram.cpp
+++ b/SampleProject/SampleProgram/SampleProgram.cpp
@@ -3,7 +3,7 @@
 #include <Features/SceneManager/SceneManager.h>
 #include <Scene/Factory/SceneFactory.h>
 #include <Features/Model/Loader/Assimp/ModelLoaderAssimp.h>
-#include <Features/Model/Loader/ModelLoaderLegacy.h>
+#include <Features/Model/Helper/ModelHelper.h>
 
 
 void SampleProgram::Initialize()
@@ -19,15 +19,9 @@ void SampleProgram::Initialize()
     pSceneFactory_ = std::make_unique<SceneFactory>();
     pSceneManager_->SetSceneFactory(pSceneFactory_.get());
 
-    pModelLoader_ = std::make_unique<ModelLoaderAssimp>();
-    pModelLoader_->Initialize();
-    pModelLoader_->SetDirectX12(pDirectX_.get());
-    pModelStorage_ = std::make_unique<ModelStorage>();
-
-    pModelManager_ = std::make_unique<ModelManager>();
-    pModelManager_->Initialize();
-    pModelManager_->SetModelLoader(pModelLoader_.get());
-    pModelManager_->SetModelStorage(pModelStorage_.get());
+    pModelLoader_ = Helper::Model::CreateLoader<ModelLoaderAssimp>(pDirectX_.get());
+    pModelStorage_ = Helper::Model::CreateStorage();
+    pModelManager_ = Helper::Model::CreateManager(pModelLoader_.get(), pModelStorage_.get());
 
     pSceneManager_->SetModelManager(pModelManager_.get());
 }


### PR DESCRIPTION
* `SceneObjects.cpp`
  - `DEBUG` プリプロセッサディレクティブを `_DEBUG` に変更
  - `GetName` メソッドを更新し、空の名前に対して "Unnamed Scene" を返すように変更

* `ModelHelper.cpp`
  - `DispatchModel` メソッドに `CreateStorage` と `CreateManager` メソッドを追加し、モデルストレージとモデルマネージャーの作成を簡素化

* `ModelHelper.h`
  - `ModelManager` と `ModelStorage` のヘッダーファイルを追加
  - `CreateLoader` テンプレートメソッドを追加し、`IModelLoader` を継承するローダーを作成

* `SampleProgram.cpp`
  - `ModelLoaderAssimp` の初期化処理を `Helper::Model::CreateLoader` を使用するように変更
  - モデルストレージとモデルマネージャーの作成を新しいヘルパーメソッドを使用して行うように変更

バイナリファイルやJSONの変更はありません。