### PR TITLE
update: NiGuiとシェーダーの改善

### DIFF
--- a/Engine/Features/SceneTransition/TransFadeInOut.cpp
+++ b/Engine/Features/SceneTransition/TransFadeInOut.cpp
@@ -63,7 +63,8 @@ void TransFadeInOut::Draw()
 
 void TransFadeInOut::Finalize()
 {
-    DebugManager::GetInstance()->DeleteComponent("Transition", name_.c_str());
+    UnregisterDebugWindowC("Transition", name_);
+    sprite_->Finalize();
 }
 
 void TransFadeInOut::DebugWindow()

--- a/Engine/Features/Sprite/Sprite.cpp
+++ b/Engine/Features/Sprite/Sprite.cpp
@@ -19,11 +19,7 @@ Sprite::Sprite()
 
 Sprite::~Sprite()
 {
-#if defined _DEBUG
 
-    DebugManager::GetInstance()->DeleteComponent("Sprite", name_.c_str());
-
-#endif
 }
 
 
@@ -33,9 +29,8 @@ void Sprite::Initialize(std::string _filepath)
     pDx12_ = pSpriteSystem_->GetDirectX12();
     device_ = pDx12_->GetDevice();
 
-#if defined _DEBUG
-    DebugManager::GetInstance()->SetComponent("Sprite", name_, std::bind(&Sprite::DebugWindow, this));
-#endif // _DEBUG && DEBUG_ENGINE
+    // デバッグウィンドウの登録
+    RegisterDebugWindowC("Sprite", name_, Sprite::DebugWindow, false);
 
     /// Create BufferResource
     // 頂点リソースを作成する
@@ -164,7 +159,8 @@ void Sprite::Draw()
 
 void Sprite::Finalize()
 {
-
+    // デバッグウィンドウの解除
+    UnregisterDebugWindowC("Sprite", name_);
 }
 
 void Sprite::SetSizeMultiply(float _multiply)
@@ -210,7 +206,6 @@ void Sprite::CreateIndexBufferView()
     indexBufferView_.SizeInBytes = sizeof(uint32_t) * 6;
     // インデックスはint32_tとする
     indexBufferView_.Format = DXGI_FORMAT_R32_UINT;
-
 }
 
 

--- a/Engine/Features/Text/Text.cpp
+++ b/Engine/Features/Text/Text.cpp
@@ -17,7 +17,7 @@ void Text::Initialize()
     pViewport_ = pTextSystem_->GetViewport();
 
 #ifdef _DEBUG
-    DebugManager::GetInstance()->SetComponent("Text", name_, std::bind(&Text::DebugWindow, this));
+    RegisterDebugWindowC("Text", name_, Text::DebugWindow, false);
 #endif // _DEBUG
 
     fontFamily_ = "Bahnschrift";
@@ -60,7 +60,7 @@ void Text::Draw()
 void Text::Finalize()
 {
 #ifdef _DEBUG
-    DebugManager::GetInstance()->DeleteComponent("Text", name_.c_str());
+    UnregisterDebugWindowC("Text", name_);
 #endif // _DEBUG
 }
 


### PR DESCRIPTION
* `TransFadeInOut`クラスの`Finalize`メソッドで、`DebugManager`のコンポーネント削除を`UnregisterDebugWindowC`に置き換え、`sprite_`の`Finalize`メソッドを呼び出すように変更。
* `Sprite`クラスのデストラクタから`DebugManager`のコンポーネント削除を削除し、`RegisterDebugWindowC`を使用してデバッグウィンドウを登録。
* `Sprite`クラスの`Finalize`メソッドでも、`DebugManager`のコンポーネント削除を`UnregisterDebugWindowC`に置き換え。
* `Text`クラスの`Initialize`メソッドで、`DebugManager`のコンポーネント登録を`RegisterDebugWindowC`に置き換え。
* `Text`クラスの`Finalize`メソッドでも、`DebugManager`のコンポーネント削除を`UnregisterDebugWindowC`に置き換え。
* Visual Studioソリューションファイル`Calms.sln`を新たに追加し、プロジェクトの構成を定義。
* `GaussianBloom`、`LuminanceOutput`、`RandomFilter`、`SeparatedGaussianFilter`、`Skinning`、`Skybox`に関連するHLSLシェーダーを追加し、必要な構造体や関数を定義。
* `Skinning`関連のシェーダーでスキニング処理のための構造体やバッファを追加し、頂点の変換を実装。
* `Skybox`シェーダーでキューブマップテクスチャを使用して空の描画を実装。

* その他、バイナリファイルやJSONファイルの変更は軽微。