### PR TITLE
feat: XInput対応ゲームパッド入力・イベント機構の追加

### DIFF
--- a/src/DebugTools/DebugManager/DebugManager.cpp
+++ b/src/DebugTools/DebugManager/DebugManager.cpp
@@ -1,4 +1,5 @@
-#include "DebugTools/DebugManager/DebugManager.h"
+#include "DebugManager.h"
+#include <Features/Input/Input.h>
 
 #include <NiGui.h>
 
@@ -11,8 +12,9 @@
 
 DebugManager* DebugManager::GetInstance()
 {
-    static DebugManager instance;
-    return &instance;
+    /// リソースの解放はOSに任せる
+    static auto instance = new DebugManager();
+    return instance;
 }
 
 DebugManager::DebugManager()
@@ -34,7 +36,6 @@ DebugManager::DebugManager()
 
 DebugManager::~DebugManager()
 {
-
 }
 
 void DebugManager::OverlayFPS() const

--- a/src/DebugTools/DebugManager/DebugManager.h
+++ b/src/DebugTools/DebugManager/DebugManager.h
@@ -9,12 +9,13 @@
 #include <string>
 #include <array>
 #include <optional>
-#include <Features/Input/Input.h>
 #include <unordered_map>
 #include <utility>
 #include <Features/Viewport/Viewport.h>
 #include <DebugTools/Logger/Logger.h>
 #include <DebugTools/EventTimer/EventTimer.h>
+
+class Input;
 
 /// <summary>
 /// デバッグマネージャー
@@ -89,7 +90,7 @@ private:
     ~DebugManager();
 
     // Input
-    Input*                  pInput_ = nullptr;
+    Input*                      pInput_ = nullptr;
 
     // Localization
     Localization::Common        lang_common_ = {};

--- a/src/Engine.vcxproj
+++ b/src/Engine.vcxproj
@@ -410,6 +410,7 @@
     <ClInclude Include="Effects\PostEffects\Vignette\Vignette.h" />
     <ClInclude Include="Effects\SceneTransition\TransShutter.h" />
     <ClInclude Include="EngineResources\Shaders\RuntimeData.hlsli" />
+    <ClInclude Include="event\InputCallbackEvent.h" />
     <ClInclude Include="Features\Animation\AnimationTimeline.hpp" />
     <ClInclude Include="Features\Animation\AnimationTween.hpp" />
     <ClInclude Include="Features\Audio\Audio.h" />

--- a/src/Engine.vcxproj.filters
+++ b/src/Engine.vcxproj.filters
@@ -1310,6 +1310,7 @@
     <ClInclude Include="Features\Lighting\PointLight.h">
       <Filter>Feature\Lighting</Filter>
     </ClInclude>
+    <ClInclude Include="event\InputCallbackEvent.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />

--- a/src/Features/Input/Input.cpp
+++ b/src/Features/Input/Input.cpp
@@ -1,14 +1,24 @@
 #include "Input.h"
 
-#include <cassert>
-#include <stdexcept>
 #include <Core/Window/Window.h>
+#include <imgui.h>
+#include <Features/event/EventListener.h>
+#include <event/InputCallbackEvent.h>
 
+#include <stdexcept>
+#include <cassert>
+#include <bitset>
+#include <sstream>
+
+#include <Xinput.h>
 #pragma comment(lib, "dinput8.lib")
 #pragma comment(lib, "dxguid.lib")
+#pragma comment(lib, "xinput9_1_0.lib")
 
 void Input::Initialize(HINSTANCE hInstance, HWND hwnd)
 {
+    pDebugEntry_ = std::make_unique<DebugEntry<Input>>("Input", this, false);
+
     HRESULT hr = DirectInput8Create(
         hInstance, DIRECTINPUT_VERSION, IID_IDirectInput8, static_cast<void**>(&directInput_), nullptr
     );
@@ -48,8 +58,6 @@ void Input::Initialize(HINSTANCE hInstance, HWND hwnd)
     mouse_->Acquire();
 
     assert(SUCCEEDED(hr));
-
-    this->InitializePad(hwnd);
 }
 
 void Input::Update()
@@ -97,7 +105,16 @@ bool Input::PushKeyC(char key) const
     {
         return true;
     }
+    return false;
+}
 
+bool Input::PushButton(BYTE buttonNum) const
+{
+    if (!isPadConnected_) return false;
+    if (padState_.Gamepad.wButtons & (1 << buttonNum))
+    {
+        return true;
+    }
     return false;
 }
 
@@ -108,7 +125,6 @@ bool Input::TriggerKey(BYTE keyNumber) const
     {
         return true;
     }
-
     return false;
 }
 
@@ -120,7 +136,19 @@ bool Input::TriggerKeyC(char key) const
     {
         return true;
     }
+    return false;
+}
 
+bool Input::TriggerButton(BYTE buttonNum) const
+{
+    if (!isPadConnected_) return false;
+    bool isPressed = (padState_.Gamepad.wButtons & (1 << buttonNum)) != 0;
+    bool wasPressed = (padStatePrev_.Gamepad.wButtons & (1 << buttonNum)) != 0;
+
+    if (isPressed && !wasPressed)
+    {
+        return true;
+    }
     return false;
 }
 
@@ -134,14 +162,85 @@ bool Input::ReleaseKey(BYTE keyNumber) const
     return false;
 }
 
-Vector2 Input::GetLeftStickPosition() const
+bool Input::ReleaseButton(BYTE buttonNum) const
 {
-    return leftStickPosition_;
+    if (!isPadConnected_) return false;
+
+    bool isPressed = (padState_.Gamepad.wButtons & (1 << buttonNum)) != 0;
+    bool wasPressed = (padStatePrev_.Gamepad.wButtons & (1 << buttonNum)) != 0;
+
+    if (!isPressed && wasPressed)
+    {
+        return true;
+    }
+    return false;
 }
 
-Vector2 Input::GetRightStickPosition() const
+bool Input::IsPadConnected() const
 {
-    return rightStickPosition_;
+    return isPadConnected_;
+}
+
+bool Input::IsPadUpdated() const
+{
+    return isPadUpdated_;
+}
+
+void Input::ImGui()
+{
+    #ifdef _DEBUG
+
+    ImGui::SeparatorText("Gamepad Connection");
+    if (isPadConnected_)
+    {
+        ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "Connected");
+
+        if (ImGui::TreeNode("Gamepad Information"))
+        {
+            if (ImGui::TreeNode("Row Gamepad State"))
+            {
+                // パケット
+                ImGui::Text("packet : %d", padState_.dwPacketNumber);
+                ImGui::Text("Last updated : %.2fsec ago", timePadNonUpdate_.GetNow<float>());
+
+                auto& gamepad = padState_.Gamepad;
+                // ボタンの生データ (2進数で表示)
+                std::stringstream buttonsBinaryString;
+                buttonsBinaryString << std::bitset<16>(gamepad.wButtons);
+                ImGui::Text("buttons : 0b%s", buttonsBinaryString.str().c_str());
+                // スティックの生データ
+                ImGui::Text("Left Stick : (%.5d,%.5d)", gamepad.sThumbLX, gamepad.sThumbLY);
+                ImGui::Text("Right Stick : (%.5d,%.5d)", gamepad.sThumbRX, gamepad.sThumbRY);
+
+                ImGui::TreePop();
+            }
+
+            if (ImGui::TreeNode("Formatted Gamepad State"))
+            {
+                ImGui::Text("Left Stick : (%f,%f)", gamepadAnalogInput_.thumbL.x, gamepadAnalogInput_.thumbL.y);
+                ImGui::Text("Right Stick : (%f,%f)", gamepadAnalogInput_.thumbR.x, gamepadAnalogInput_.thumbR.y);
+
+                ImGui::TreePop();
+            }
+
+            ImGui::TreePop();
+        }
+    }
+    else
+    {
+        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "Disconnected");
+    }
+
+    if (ImGui::TreeNode("Gamepad Setting"))
+    {
+        ImGui::SeparatorText("Deadzone");
+        ImGui::SliderFloat("Trigger Left", &deadzone_.triggerL, 0.0f, 1.0f);
+        ImGui::SliderFloat("Trigger Right", &deadzone_.triggerR, 0.0f, 1.0f);
+        ImGui::SliderFloat("Thumb Left", &deadzone_.thumbL, 0.0f, 1.0f);
+        ImGui::SliderFloat("Thumb Right", &deadzone_.thumbR, 0.0f, 1.0f);
+        ImGui::TreePop();
+    }
+    #endif // _DEBUG
 }
 
 POINT Input::GetCursorPosition() const
@@ -194,6 +293,11 @@ int32_t Input::GetWheelDelta() const
     return wheelDelta_;
 }
 
+bool Input::IsAnyKeyChanged() const
+{
+    return std::memcmp(key_, keyPre_, 256) != 0;
+}
+
 BYTE Input::GetKeyNumber(char key) const
 {
     // キーの文字からキー番号を取得
@@ -236,79 +340,62 @@ void Input::MapInputData()
     wheelDelta_ = mouseState_.lZ;
 }
 
-void Input::InitializePad(HWND hwnd)
-{
-    HRESULT hr = directInput_->EnumDevices(
-        DI8DEVTYPE_GAMEPAD, EnumJoystickCallback, (void*)this, DIEDFL_ATTACHEDONLY
-    );
-    assert(SUCCEEDED(hr));
-
-    if (!pad_) return;
-
-    hr = pad_->SetDataFormat(&c_dfDIJoystick2);
-    assert(SUCCEEDED(hr));
-
-    // 軸を絶対値モードに設定
-    {
-        DIPROPDWORD prop;
-        ZeroMemory(&prop, sizeof(prop));
-        prop.diph.dwSize = sizeof(prop);
-        prop.diph.dwHeaderSize = sizeof(prop.diph);
-        prop.diph.dwHow = DIPH_DEVICE;
-        prop.diph.dwObj = 0;
-        prop.dwData = DIPROPAXISMODE_ABS;
-        hr = pad_->SetProperty(DIPROP_AXISMODE, &prop.diph);
-    }
-    assert(SUCCEEDED(hr));
-
-    // ジョイスティックの範囲を設定
-    {
-        DIPROPRANGE prop;
-        ZeroMemory(&prop, sizeof(prop));
-        prop.diph.dwSize = sizeof(prop);
-        prop.diph.dwHeaderSize = sizeof(prop.diph);
-        prop.diph.dwHow = DIPH_BYOFFSET;
-        prop.diph.dwObj = DIJOFS_X;
-        prop.lMin = -kStickRange;
-        prop.lMax = kStickRange;
-        hr = pad_->SetProperty(DIPROP_RANGE, &prop.diph);
-        // Y軸の範囲も同様に設定
-        prop.diph.dwObj = DIJOFS_Y;
-        hr = pad_->SetProperty(DIPROP_RANGE, &prop.diph);
-    }
-    assert(SUCCEEDED(hr));
-
-    // ジョイスティックの排他制御レベルを設定
-    hr = pad_->SetCooperativeLevel(
-        hwnd, DISCL_BACKGROUND | DISCL_NONEXCLUSIVE
-    );
-    assert(SUCCEEDED(hr));
-
-    // ジョイスティックの情報の取得を開始
-    hr = pad_->Acquire();
-    assert(SUCCEEDED(hr));
-}
-
 void Input::UpdatePad()
 {
-    if (!pad_) return;
-    leftStickPosition_.x = padState_.lX / static_cast<float>(kStickRange); // X軸の値を-1.0fから1.0fに変換
-    leftStickPosition_.y = padState_.lY / static_cast<float>(kStickRange); // Y軸の値を-1.0fから1.0fに変換
-    rightStickPosition_.x = padState_.lRx / static_cast<float>(kStickRange); // 右スティックX軸
-    rightStickPosition_.y = padState_.lRy / static_cast<float>(kStickRange); // 右スティックY軸
+    padStatePrev_ = padState_;
 
-    // ボタンの状態を更新
-    for (int i = 0; i < 32; ++i)
+    bool wasPadConnected = isPadConnected_;
+    isPadConnected_ = false;
+    DWORD dwResult;
+    for (DWORD i = 0; i < XUSER_MAX_COUNT; ++i)
     {
-        if (padState_.rgbButtons[i] & 0x80)
+        ZeroMemory(&padState_, sizeof(XINPUT_STATE));
+        dwResult = XInputGetState(i, &padState_);
+        if (dwResult == ERROR_SUCCESS)
         {
-            buttons_[i] = true; // ボタンが押されている
-        }
-        else
-        {
-            buttons_[i] = false; // ボタンが離されている
+            /// コントローラーが接続されている
+            isPadConnected_ = true;
+            break;
         }
     }
+
+    /// コントローラーの接続状態が変化した場合、イベントを発行
+    bool isConnectedNow = isPadConnected_ && !wasPadConnected;
+    bool isDisconnectedNow = !isPadConnected_ && wasPadConnected;
+
+    if (isConnectedNow)
+    {
+        EventListener::GetInstance()->Publish(Events::GamePadConnected());
+    }
+    else if (isDisconnectedNow)
+    {
+        EventListener::GetInstance()->Publish(Events::GamePadDisconnected());
+    }
+
+    /// コントローラが接続されていない場合はここで終わり
+    if (!isPadConnected_) return;
+
+    isPadUpdated_ = padState_.dwPacketNumber != padStatePrev_.dwPacketNumber;
+    if (isPadUpdated_)
+    {
+        timePadNonUpdate_.Reset();
+        timePadNonUpdate_.Start();
+    }
+
+    auto& gamepad = padState_.Gamepad;
+    auto& analog = gamepadAnalogInput_;
+    analog.thumbL.x    = std::max(-1.0f, static_cast<float>(gamepad.sThumbLX) / 32767.0f); // X軸の値を-1.0fから1.0fに変換
+    analog.thumbL.y    = std::max(-1.0f, static_cast<float>(gamepad.sThumbLY) / 32767.0f); // Y軸の値を-1.0fから1.0fに変換
+    analog.thumbR.x    = std::max(-1.0f, static_cast<float>(gamepad.sThumbRX) / 32767.0f); // 右スティックX軸
+    analog.thumbR.y    = std::max(-1.0f, static_cast<float>(gamepad.sThumbRY) / 32767.0f); // 右スティックY軸
+    analog.triggerL    = static_cast<float>(gamepad.bLeftTrigger) / 255.0f; // 左トリガーの値を0.0fから1.0fに変換
+    analog.triggerR    = static_cast<float>(gamepad.bRightTrigger) / 255.0f; // 右トリガーの値を0.0fから1.0fに変換
+
+    /// デッドゾーンの処理
+    if (gamepadAnalogInput_.thumbL.LengthWithoutRoot() <= deadzone_.thumbL) gamepadAnalogInput_.thumbL = Vector2();
+    if (gamepadAnalogInput_.thumbR.LengthWithoutRoot() <= deadzone_.thumbR) gamepadAnalogInput_.thumbR = Vector2();
+    if (gamepadAnalogInput_.triggerL <= deadzone_.triggerL) gamepadAnalogInput_.triggerL = 0.0f;
+    if (gamepadAnalogInput_.triggerR <= deadzone_.triggerR) gamepadAnalogInput_.triggerR = 0.0f;
 }
 
 void Input::UpdateDeviceState(IDirectInputDevice8* pDevice, LPVOID out_state, size_t sizeState)
@@ -350,16 +437,4 @@ void Input::UpdateCursorPosition()
     float ratio = static_cast<float>(Window::clientHeight) / static_cast<float>(viewportSize_.cy);
     mousePosition_.x = static_cast<LONG>(static_cast<float>(mousePosition_.x) * ratio);
     mousePosition_.y = static_cast<LONG>(static_cast<float>(mousePosition_.y) * ratio);
-}
-
-int Input::EnumJoystickCallback(const DIDEVICEINSTANCE* pdidInstance, void* context)
-{
-    auto pInput = static_cast<Input*>(context);
-    auto directInput = pInput->GetDirectInput();
-    
-    if (FAILED(directInput->CreateDevice(pdidInstance->guidInstance, pInput->GetPad(), nullptr)))
-    {
-        return DIENUM_CONTINUE; // エラーが発生した場合は次のデバイスへ
-    }
-    return DIENUM_STOP; // ジョイスティックが見つかったので列挙を停止
 }

--- a/src/Features/Input/Input.cpp
+++ b/src/Features/Input/Input.cpp
@@ -108,14 +108,10 @@ bool Input::PushKeyC(char key) const
     return false;
 }
 
-bool Input::PushButton(BYTE buttonNum) const
+bool Input::PushButton(WORD buttonNum) const
 {
     if (!isPadConnected_) return false;
-    if (padState_.Gamepad.wButtons & (1 << buttonNum))
-    {
-        return true;
-    }
-    return false;
+    return (padState_.Gamepad.wButtons & buttonNum) != 0;
 }
 
 bool Input::TriggerKey(BYTE keyNumber) const
@@ -139,11 +135,11 @@ bool Input::TriggerKeyC(char key) const
     return false;
 }
 
-bool Input::TriggerButton(BYTE buttonNum) const
+bool Input::TriggerButton(WORD buttonNum) const
 {
     if (!isPadConnected_) return false;
-    bool isPressed = (padState_.Gamepad.wButtons & (1 << buttonNum)) != 0;
-    bool wasPressed = (padStatePrev_.Gamepad.wButtons & (1 << buttonNum)) != 0;
+    bool isPressed = (padState_.Gamepad.wButtons & buttonNum) != 0;
+    bool wasPressed = (padStatePrev_.Gamepad.wButtons & buttonNum) != 0;
 
     if (isPressed && !wasPressed)
     {
@@ -162,17 +158,37 @@ bool Input::ReleaseKey(BYTE keyNumber) const
     return false;
 }
 
-bool Input::ReleaseButton(BYTE buttonNum) const
+bool Input::ReleaseButton(WORD buttonNum) const
 {
     if (!isPadConnected_) return false;
 
-    bool isPressed = (padState_.Gamepad.wButtons & (1 << buttonNum)) != 0;
-    bool wasPressed = (padStatePrev_.Gamepad.wButtons & (1 << buttonNum)) != 0;
+    bool isPressed = (padState_.Gamepad.wButtons & buttonNum) != 0;
+    bool wasPressed = (padStatePrev_.Gamepad.wButtons & buttonNum) != 0;
 
     if (!isPressed && wasPressed)
     {
         return true;
     }
+    return false;
+}
+
+bool Input::ReleaseMouse(MouseNum mouseNum) const
+{
+    if (mouseNum == MouseNum::Left)
+    {
+        if (!leftClick_ && leftClickPre_)
+        {
+            return true;
+        }
+    }
+    else if (mouseNum == MouseNum::Right)
+    {
+        if (!rightClick_ && rightClickPre_)
+        {
+            return true;
+        }
+    }
+
     return false;
 }
 

--- a/src/Features/Input/Input.h
+++ b/src/Features/Input/Input.h
@@ -94,16 +94,17 @@ public:
     /// 状態の取得
     bool        PushKey(BYTE keyNumber) const;
     bool        PushKeyC(char key) const;
-    bool        PushButton(BYTE buttonNum) const;
+    bool        PushButton(WORD buttonNum) const;
     bool        PushMouse(MouseNum mouseNum) const;
 
     bool        TriggerKey(BYTE keyNumber) const;
     bool        TriggerKeyC(char key) const;
-    bool        TriggerButton(BYTE buttonNum) const;
+    bool        TriggerButton(WORD buttonNum) const;
     bool        TriggerMouse(MouseNum mouseNum) const;
 
     bool        ReleaseKey(BYTE keyNumber) const;
-    bool        ReleaseButton(BYTE buttonNum) const;
+    bool        ReleaseButton(WORD buttonNum) const;
+    bool        ReleaseMouse(MouseNum mouseNum) const;
 
     POINT       GetCursorPosition() const;
     int32_t     GetWheelDelta() const;

--- a/src/Features/Input/Input.h
+++ b/src/Features/Input/Input.h
@@ -2,10 +2,27 @@
 
 #define DIRECTINPUT_VERSION 0x0800
 
+#include <Xinput.h>
 #include <dinput.h>
 #include <wrl.h>
 #include <cstdint>
 #include <Vector2.h>
+#include <list>
+#include <DebugTools/DebugEntry/DebugEntry.h>
+#include <memory>
+#include <limits>
+
+#undef max
+
+/// ## コントローラの接続時/切断時のコールバック
+/// コントローラの接続状態が変化したときにイベントを発行します。
+/// コントローラが接続されたときはEvents::GamePadConnectedイベントを、切断されたときはEvents::GamePadDisconnectedイベントを発行します。
+/// EventListenerクラスを使用してイベントを購読してください。
+/// ## コントローラのスティックやトリガーの取得について
+/// コントローラのスティックやトリガーの値は、GamepadAnalogInput構造体にまとめられています。
+/// 一般にゲームで使用する場合は、GetGamepadAnalogInput関数を使用して、スティックやトリガーの値を取得してください。
+/// この関数で取得できる値は、デッドゾーンを考慮して補正された値です。
+/// 例外的に、スティックやトリガーの生の値が必要な場合は、GetRawGamepadState関数を使用して、XINPUT_GAMEPAD構造体から取得してください。
 
 /// <summary>
 /// 入力管理クラス
@@ -18,6 +35,22 @@ public:
         Left = 0,
         Right = 1,
         Center = 2,
+    };
+
+    struct Deadzone
+    {
+        float thumbL = 0.1f;
+        float thumbR = 0.1f;
+        float triggerL = 0.1f;
+        float triggerR = 0.1f;
+    };
+
+    struct GamepadAnalogInput
+    {
+        Vector2 thumbL = {};
+        Vector2 thumbR = {};
+        float triggerL = 0.0f;
+        float triggerR = 0.0f;
     };
 
     Input(const Input&) = delete;
@@ -37,6 +70,7 @@ public:
     /// <param name="hInstance">アプリケーションインスタンス。</param>
     /// <param name="hwnd">ウィンドウハンドル。</param>
     void        Initialize(HINSTANCE hInstance, HWND hwnd);
+
     /// <summary>
     /// 入力状態を更新します。
     /// キーボード/マウス/パッドの状態を取得して内部に反映します。
@@ -49,86 +83,101 @@ public:
     /// <param name="flag">trueで有効。</param>
     void        Enable(bool flag);
 
-    void        SetDeadZoneRange(float deadZoneRange) { deadZoneRange_ = deadZoneRange; }
     void        SetWindowOffset(POINT offset) { viewportOffset_ = offset; }
     void        SetWindowSize(SIZE size) { viewportSize_ = size; }
+
+    Deadzone&   GetDeadzone() { return deadzone_; }
+    const Deadzone& GetDeadzone() const { return deadzone_; }
+    const GamepadAnalogInput& GetGamepadAnalogInput() const { return gamepadAnalogInput_; }
+    const XINPUT_GAMEPAD& GetRawGamepadState() const { return padState_.Gamepad; }
 
     /// 状態の取得
     bool        PushKey(BYTE keyNumber) const;
     bool        PushKeyC(char key) const;
+    bool        PushButton(BYTE buttonNum) const;
+    bool        PushMouse(MouseNum mouseNum) const;
+
     bool        TriggerKey(BYTE keyNumber) const;
     bool        TriggerKeyC(char key) const;
-    bool        ReleaseKey(BYTE keyNumber) const;
-    Vector2     GetLeftStickPosition() const;
-    Vector2     GetRightStickPosition() const;
-    POINT       GetCursorPosition() const;
-
-    bool        PushMouse(MouseNum mouseNum) const;
+    bool        TriggerButton(BYTE buttonNum) const;
     bool        TriggerMouse(MouseNum mouseNum) const;
+
+    bool        ReleaseKey(BYTE keyNumber) const;
+    bool        ReleaseButton(BYTE buttonNum) const;
+
+    POINT       GetCursorPosition() const;
     int32_t     GetWheelDelta() const;
+
+    bool        IsAnyKeyChanged() const;
+    bool        IsPadConnected() const;
+    bool        IsPadUpdated() const;
+
     IDirectInput8* GetDirectInput() const { return directInput_.Get(); }
     IDirectInputDevice8** GetPad() { return pad_.GetAddressOf(); }
 
+    void        ImGui();
 
 private:
     Input() = default;
     ~Input() = default;
     
-    // Internal functions
-    static BOOL CALLBACK EnumJoystickCallback(const DIDEVICEINSTANCE* pdidInstance, void* context);
     /// <summary>
     /// 文字からDirectInputのキー番号へ変換します。
     /// </summary>
     BYTE GetKeyNumber(char key) const;
+
     /// <summary>
     /// デバイスの生入力から論理入力へマッピングします。
     /// </summary>
     void MapInputData();
-    /// <summary>
-    /// ゲームパッドを初期化します。
-    /// </summary>
-    void InitializePad(HWND hwnd);
+
     /// <summary>
     /// ゲームパッド状態を更新します。
     /// </summary>
     void UpdatePad();
+
     /// <summary>
     /// 指定デバイスの状態を更新します。
     /// </summary>
     void UpdateDeviceState(IDirectInputDevice8* pDevice, LPVOID out_state, size_t sizeState);
+
     /// <summary>
     /// カーソル位置を更新します。
     /// </summary>
     void UpdateCursorPosition();
 
+    // デバッグエントリ
+    std::unique_ptr<DebugEntry<Input>> pDebugEntry_ = nullptr;
+
     // State
     bool isEnable_ = true;
-
-    // Config
-    const int32_t kStickRange = 1000; // ジョイスティックの範囲
 
     // DirectInput data
     Microsoft::WRL::ComPtr<IDirectInput8> directInput_ = nullptr;
     Microsoft::WRL::ComPtr<IDirectInputDevice8> keyboard_ = nullptr;
     Microsoft::WRL::ComPtr<IDirectInputDevice8> mouse_ = nullptr;
     Microsoft::WRL::ComPtr<IDirectInputDevice8> pad_ = nullptr;
-    DIMOUSESTATE2 mouseState_ = {};
-    DIJOYSTATE2 padState_ = {};
+    DIMOUSESTATE2   mouseState_ = {};
+    XINPUT_STATE    padState_ = {};
+    XINPUT_STATE    padStatePrev_ = {};
+
+    bool    isPadConnected_     = false;
+    bool    isPadUpdated_       = false;
+
+    // コントローラの入力が最後に更新されてからの時間を測るためのタイマー
+    TimeMeasurer            timePadNonUpdate_       = {};
 
     // Logical input data
-    BYTE    key_[256]           = {};
-    BYTE    keyPre_[256]        = {};
-    bool    leftClick_          = false;
-    bool    leftClickPre_       = false;
-    bool    rightClick_         = false;
-    bool    rightClickPre_      = false;
-    int32_t wheelDelta_         = 0;
-    Vector2 leftStickPosition_  = { 0.0f, 0.0f };
-    Vector2 rightStickPosition_ = { 0.0f, 0.0f };
-    bool    buttons_[32]        = {}; // ボタンの状態
-    bool    buttonsPre_[32]     = {}; // 前回のボタン状態
-    float   deadZoneRange_      = 0.1f;  // ジョイスティックのデッドゾーン範囲
-    POINT   mousePosition_      = { 0, 0 };
-    POINT   viewportOffset_     = { 0, 0 };
-    SIZE    viewportSize_       = { 0, 0 };
+    BYTE                    key_[256]               = {};
+    BYTE                    keyPre_[256]            = {};
+    bool                    leftClick_              = false;
+    bool                    leftClickPre_           = false;
+    bool                    rightClick_             = false;
+    bool                    rightClickPre_          = false;
+    int32_t                 wheelDelta_             = 0;
+    Deadzone                deadzone_               = {};
+    GamepadAnalogInput      gamepadAnalogInput_     = {};
+    POINT                   mousePosition_          = { 0, 0 };
+    POINT                   viewportOffset_         = { 0, 0 };
+    SIZE                    viewportSize_           = { 0, 0 };
 };

--- a/src/event/InputCallbackEvent.h
+++ b/src/event/InputCallbackEvent.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace Events
+{
+    struct GamePadConnected
+    {
+    };
+
+    struct GamePadDisconnected
+    {
+    };
+};


### PR DESCRIPTION
## Inputクラス
- XInputによるゲームパッド入力に対応し、DirectInputベースの古いゲームパッド実装を削除
- Deadzone構造体・GamepadAnalogInput構造体を追加し、スティック・トリガーのデッドゾーン補正値を管理
- ゲームパッドのボタン押下/トリガ/リリース判定API（PushButton, TriggerButton, ReleaseButton）を追加
- ゲームパッドの接続状態・更新有無の取得API（IsPadConnected, IsPadUpdated）を追加
- ゲームパッドの生状態（XINPUT_GAMEPAD）取得APIを追加
- ImGuiによるデバッグ表示・デッドゾーン調整機能を追加
- ゲームパッドの接続・切断時にイベントを発行する仕組みを追加

## Events
- event/InputCallbackEvent.hを新規追加
- ゲームパッド接続/切断イベント（GamePadConnected, GamePadDisconnected）を定義

## DebugManager
- Inputヘッダの参照パス修正
- Inputインスタンス取得方法を変更

## プロジェクトファイル
- Engine.vcxproj, .filtersにevent/InputCallbackEvent.hを追加

**備考:**
DirectInputによるジョイスティック列挙・状態管理コードは完全に削除され、今後はXInputベースでのゲームパッド入力のみ対応となります。